### PR TITLE
fix: make “不使用项目” switch out of the active project

### DIFF
--- a/apps/desktop-legalwork/legalwork/src/domain/thread.ts
+++ b/apps/desktop-legalwork/legalwork/src/domain/thread.ts
@@ -1,3 +1,5 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import type {
   ThreadMode,
   ThreadRecord,
@@ -19,6 +21,15 @@ import {
  * services and stores can stay free of date-string formatting.
  */
 export type ThreadEntity = ThreadRecord
+
+export function expandThreadWorkspace(raw: string): string {
+  const value = raw.trim()
+  if (value === '~') return homedir()
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return join(homedir(), value.slice(2))
+  }
+  return value
+}
 
 export function createThreadRecord(input: {
   id: string
@@ -46,7 +57,7 @@ export function createThreadRecord(input: {
   return {
     id: input.id,
     title: input.title,
-    workspace: input.workspace,
+    workspace: expandThreadWorkspace(input.workspace),
     model: input.model,
     mode: input.mode ?? 'agent',
     status: input.status ?? 'idle',

--- a/apps/desktop-legalwork/legalwork/tests/thread-workspace.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/thread-workspace.test.ts
@@ -1,0 +1,24 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createThreadRecord, expandThreadWorkspace } from '../src/domain/thread.js'
+
+describe('thread workspace expansion', () => {
+  it('expands the home directory marker', () => {
+    expect(expandThreadWorkspace('~')).toBe(homedir())
+    expect(expandThreadWorkspace('~/.legalwork/no_project_workspace')).toBe(
+      join(homedir(), '.legalwork', 'no_project_workspace')
+    )
+  })
+
+  it('persists an absolute workspace on new threads', () => {
+    const thread = createThreadRecord({
+      id: 'thr_no_project',
+      title: 'No project',
+      workspace: '~/.legalwork/no_project_workspace',
+      model: 'deepseek-chat'
+    })
+
+    expect(thread.workspace).toBe(join(homedir(), '.legalwork', 'no_project_workspace'))
+  })
+})

--- a/apps/desktop-legalwork/src/renderer/src/components/chat/NewConversationProjectPicker.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/chat/NewConversationProjectPicker.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown, Folder, FolderPlus, FolderX, Search } from 'lucide-
 import type { NormalizedThread } from '../../agent/types'
 import { workspaceLabelFromPath } from '../../lib/workspace-label'
 import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from '../../lib/workspace-path'
+import { isNoProjectWorkspaceRoot } from '@shared/workspace-context'
 import { buildSidebarWorkspaceGroups } from './SidebarProjectsSection'
 
 type Props = {
@@ -42,6 +43,7 @@ export function NewConversationProjectPicker({
   const menuRef = useRef<HTMLDivElement | null>(null)
   const selectedWorkspace = normalizeWorkspaceRoot(workspaceRoot)
   const selectedWorkspaceKey = workspaceRootIdentityKey(selectedWorkspace)
+  const noProjectSelected = isNoProjectWorkspaceRoot(selectedWorkspace)
 
   const groups = useMemo(() => {
     return buildSidebarWorkspaceGroups({
@@ -50,7 +52,7 @@ export function NewConversationProjectPicker({
       showArchived: false,
       workspaceRoot,
       workspaceRoots
-    })
+    }).filter(([workspacePath]) => !isNoProjectWorkspaceRoot(workspacePath))
   }, [query, threads, workspaceRoot, workspaceRoots])
 
   useEffect(() => {
@@ -185,12 +187,16 @@ export function NewConversationProjectPicker({
             </button>
             <button
               type="button"
-              role="menuitem"
+              role="menuitemradio"
+              aria-checked={noProjectSelected}
               onClick={clearWorkspace}
               className="flex w-full items-center gap-3 rounded-lg px-1 py-2 text-left text-[14px] font-medium text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink focus:bg-ds-hover focus-visible:bg-ds-hover focus-visible:outline-none"
             >
               <FolderX className="h-4 w-4 shrink-0 text-ds-faint" strokeWidth={1.75} />
               <span className="min-w-0 flex-1 truncate">{t('newConversationProjectNone')}</span>
+              {noProjectSelected ? (
+                <Check className="h-4 w-4 shrink-0 text-ds-muted" strokeWidth={2} />
+              ) : null}
             </button>
           </div>
         </div>

--- a/apps/desktop-legalwork/src/renderer/src/components/chat/NewConversationProjectPicker.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/chat/NewConversationProjectPicker.tsx
@@ -4,7 +4,10 @@ import { Check, ChevronDown, Folder, FolderPlus, FolderX, Search } from 'lucide-
 import type { NormalizedThread } from '../../agent/types'
 import { workspaceLabelFromPath } from '../../lib/workspace-label'
 import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from '../../lib/workspace-path'
-import { isNoProjectWorkspaceRoot } from '@shared/workspace-context'
+import {
+  isNoProjectWorkspaceRoot,
+  NO_PROJECT_WORKSPACE_ROOT
+} from '@shared/workspace-context'
 import { buildSidebarWorkspaceGroups } from './SidebarProjectsSection'
 
 type Props = {
@@ -34,7 +37,6 @@ export function NewConversationProjectPicker({
   runtimeReady,
   onSelectWorkspace,
   onPickWorkspace,
-  onClearWorkspace,
   t
 }: Props): ReactElement {
   const [open, setOpen] = useState(false)
@@ -105,7 +107,7 @@ export function NewConversationProjectPicker({
 
   const clearWorkspace = (): void => {
     setOpen(false)
-    onClearWorkspace()
+    onSelectWorkspace(NO_PROJECT_WORKSPACE_ROOT)
   }
 
   return (

--- a/apps/desktop-legalwork/src/renderer/src/lib/workspace-label.ts
+++ b/apps/desktop-legalwork/src/renderer/src/lib/workspace-label.ts
@@ -1,4 +1,5 @@
 import i18n from '../i18n'
+import { isNoProjectWorkspaceRoot } from '@shared/workspace-context'
 
 const DEFAULT_WORKSPACE_PATH_SUFFIX = '/.legalwork/default_workspace'
 const LEGACY_DEFAULT_WORKSPACE_PATH_SUFFIX = '/.deepseekgui/default_workspace'
@@ -21,6 +22,7 @@ function isDefaultWorkspacePath(path: string): boolean {
 export function workspaceLabelFromPath(path: string): string {
   const p = path?.trim() ?? ''
   if (!p) return i18n.t('common:workingDirectory')
+  if (isNoProjectWorkspaceRoot(p)) return i18n.t('common:newConversationProjectNone')
   if (isDefaultWorkspacePath(p)) return DEFAULT_WORKSPACE_LABEL
   const normalized = p.replace(/[/\\]+$/, '')
   const parts = normalized.split(/[/\\]/)

--- a/apps/desktop-legalwork/src/renderer/src/lib/workspace-path.test.ts
+++ b/apps/desktop-legalwork/src/renderer/src/lib/workspace-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNoProjectWorkspaceRoot,
+  NO_PROJECT_WORKSPACE_ROOT
+} from '@shared/workspace-context'
+import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from './workspace-path'
+
+describe('no-project workspace', () => {
+  it('recognizes both the portable marker and expanded home paths', () => {
+    expect(isNoProjectWorkspaceRoot(NO_PROJECT_WORKSPACE_ROOT)).toBe(true)
+    expect(isNoProjectWorkspaceRoot('/Users/test/.legalwork/no_project_workspace')).toBe(true)
+    expect(isNoProjectWorkspaceRoot('C:\\Users\\test\\.legalwork\\no_project_workspace\\')).toBe(true)
+  })
+
+  it('canonicalizes expanded paths to one stable identity', () => {
+    expect(normalizeWorkspaceRoot('/Users/test/.legalwork/no_project_workspace')).toBe(
+      NO_PROJECT_WORKSPACE_ROOT
+    )
+    expect(workspaceRootIdentityKey('/Users/test/.legalwork/no_project_workspace')).toBe(
+      NO_PROJECT_WORKSPACE_ROOT
+    )
+    expect(workspaceRootIdentityKey(NO_PROJECT_WORKSPACE_ROOT)).toBe(
+      NO_PROJECT_WORKSPACE_ROOT
+    )
+  })
+
+  it('does not change ordinary project paths', () => {
+    expect(normalizeWorkspaceRoot('/Users/test/legalwork')).toBe('/Users/test/legalwork')
+    expect(isNoProjectWorkspaceRoot('/Users/test/legalwork')).toBe(false)
+  })
+})

--- a/apps/desktop-legalwork/src/renderer/src/lib/workspace-path.ts
+++ b/apps/desktop-legalwork/src/renderer/src/lib/workspace-path.ts
@@ -1,3 +1,8 @@
+import {
+  isNoProjectWorkspaceRoot,
+  NO_PROJECT_WORKSPACE_ROOT
+} from '@shared/workspace-context'
+
 function normalizePathForMatch(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
 }
@@ -5,6 +10,7 @@ function normalizePathForMatch(path: string): string {
 export function workspaceRootIdentityKey(path?: string): string {
   const trimmed = path?.trim() ?? ''
   if (!trimmed) return ''
+  if (isNoProjectWorkspaceRoot(trimmed)) return NO_PROJECT_WORKSPACE_ROOT
   const normalized = normalizePathForMatch(trimmed)
   if (
     normalized === '~/.deepseekgui/default_workspace'
@@ -55,6 +61,7 @@ export function isInternalDeepSeekGuiWorkspace(path?: string): boolean {
 export function normalizeWorkspaceRoot(path?: string): string {
   const trimmed = path?.trim() ?? ''
   if (!trimmed) return ''
+  if (isNoProjectWorkspaceRoot(trimmed)) return NO_PROJECT_WORKSPACE_ROOT
   if (isInternalTemporaryWorkspace(trimmed)) return ''
   return trimmed
 }

--- a/apps/desktop-legalwork/src/shared/workspace-context.ts
+++ b/apps/desktop-legalwork/src/shared/workspace-context.ts
@@ -1,0 +1,17 @@
+export const NO_PROJECT_WORKSPACE_ROOT = '~/.legalwork/no_project_workspace'
+
+const NO_PROJECT_WORKSPACE_SUFFIX = '/.legalwork/no_project_workspace'
+
+function normalizePathForMatch(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+export function isNoProjectWorkspaceRoot(path?: string | null): boolean {
+  const value = path?.trim() ?? ''
+  if (!value) return false
+  const normalized = normalizePathForMatch(value)
+  return (
+    normalized === NO_PROJECT_WORKSPACE_ROOT.toLowerCase()
+    || normalized.endsWith(NO_PROJECT_WORKSPACE_SUFFIX)
+  )
+}


### PR DESCRIPTION
## 问题

“新会话”已有一个绑定当前项目的空线程时，点击“ 不使用项目 ”只清空设置，没有走项目切换逻辑，因此活动线程仍属于原项目，界面看起来完全没有切换。

## 修改

- 将“ 不使用项目 ”映射到隔离目录 `~/.legalwork/no_project_workspace`，避免继承原项目文件与上下文
- 点击该选项时复用现有的 `onSelectWorkspace` 切换链路，立即从当前空项目线程切换出去
- 在线程领域层统一展开 `~`，确保工具实际使用绝对工作目录；同时修正原有 `workspace: '~'` 的潜在相对路径问题
- 对展开后的绝对路径和 `~` 路径做统一规范化，避免被识别成两个项目
- 项目选择器不再把内部目录重复列为普通项目，并为“ 不使用项目 ”显示选中勾选
- 增加 renderer 路径规范化测试和 runtime 工作目录展开测试

## 结果

点击“ 不使用项目 ”后，新会话立即脱离原项目；后续发送消息仍可正常运行，但不会继承原项目目录和项目上下文。

## 验证

仓库当前没有针对 PR 自动运行的 workflow；已补充针对关键路径的 Vitest 测试，待本地执行 `npm test` / `npm run typecheck`。