### PR TITLE
Improve document template library density

### DIFF
--- a/apps/desktop-legalwork/src/renderer/src/components/chat/Sidebar.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/chat/Sidebar.tsx
@@ -264,7 +264,7 @@ export function Sidebar({
         ) : null}
       </div>
 
-      <div className="ds-no-drag mx-1 my-3" />
+      <div className={`ds-no-drag mx-1 ${activeView === 'documentWriting' ? 'my-1' : 'my-3'}`} />
 
       {connectPhoneSidebarOpen ? (
         <ConnectPhoneSidebarPanel

--- a/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  BookOpen,
   FilePenLine,
   FileText,
   Scale,
@@ -9,7 +8,8 @@ import {
   User,
   Trash2,
   Loader2,
-  RefreshCw
+  RefreshCw,
+  Upload
 } from 'lucide-react'
 import type { LegalTemplate, TemplateCategory } from './legal-templates'
 import { AstryxSegmentedControl } from '../astryx/AstryxSegmentedControl'
@@ -19,10 +19,10 @@ type Props = {
   activeCategory: TemplateCategory | 'all'
   activeTemplateId: string | null
   searchQuery: string
-  showUserTemplates: boolean
   onSelectTemplate: (template: LegalTemplate) => void
   onCategoryChange: (category: TemplateCategory | 'all') => void
   onSearchQueryChange: (query: string) => void
+  onUploadTemplate?: () => void
   onDeleteUserTemplate?: (templateId: string) => void
   onRetryUserTemplate?: (templateId: string) => void
   deletingTemplateId?: string | null
@@ -40,10 +40,10 @@ export function DocumentTemplateLibrary({
   activeCategory,
   activeTemplateId,
   searchQuery,
-  showUserTemplates,
   onSelectTemplate,
   onCategoryChange,
   onSearchQueryChange,
+  onUploadTemplate,
   onDeleteUserTemplate,
   onRetryUserTemplate,
   deletingTemplateId,
@@ -64,25 +64,15 @@ export function DocumentTemplateLibrary({
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="ds-no-drag shrink-0 px-4 pb-3 pt-4">
-        <div className="flex items-center gap-2">
-          <BookOpen className="h-5 w-5 text-[var(--ds-accent)]" strokeWidth={1.75} />
-          <h2 className="text-[15px] font-semibold text-[var(--ds-ink)]">
-            {t('documentWritingTemplateLibrary')}
-          </h2>
-        </div>
-      </div>
-
-      {/* Search */}
-      <div className="ds-no-drag shrink-0 px-4 pb-3">
-        <div className="relative">
+      <div className="ds-no-drag shrink-0 px-4 pb-1.5 pt-1">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <div className="relative min-w-0 flex-1">
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => onSearchQueryChange(e.target.value)}
             placeholder={t('documentWritingSearchPlaceholder')}
-            className="w-full rounded-[8px] border border-[var(--ds-sidebar-row-ring)] bg-[var(--ds-sidebar-field-bg)] px-3 py-1.5 pl-9 text-[13px] text-[var(--ds-ink)] placeholder-[var(--ds-faint)] outline-none transition focus:border-[var(--ds-accent)] focus:ring-1 focus:ring-[var(--ds-accent)]"
+            className="h-8 w-full rounded-[8px] border border-[var(--ds-sidebar-row-ring)] bg-[var(--ds-sidebar-field-bg)] px-3 pl-8 text-[12.5px] text-[var(--ds-ink)] placeholder-[var(--ds-faint)] outline-none transition focus:border-[var(--ds-accent)] focus:ring-1 focus:ring-[var(--ds-accent)]"
           />
           <FileText className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--ds-faint)]" strokeWidth={1.75} />
           {searchQuery && (
@@ -96,36 +86,44 @@ export function DocumentTemplateLibrary({
               </svg>
             </button>
           )}
+          </div>
+          {onUploadTemplate ? (
+            <button
+              type="button"
+              onClick={onUploadTemplate}
+              title={t('documentWritingUploadTemplate')}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] border border-[var(--ds-sidebar-row-ring)] bg-[var(--ds-sidebar-field-bg)] text-[var(--ds-muted)] transition hover:bg-[var(--ds-sidebar-field-focus)] hover:text-[var(--ds-ink)]"
+            >
+              <Upload className="h-3.5 w-3.5" strokeWidth={1.8} />
+            </button>
+          ) : null}
         </div>
       </div>
 
       {/* Category tabs */}
-      <div className="ds-no-drag shrink-0 px-4 pb-3">
+      <div className="ds-no-drag shrink-0 px-4 pb-1.5">
         <AstryxSegmentedControl
           value={activeCategory}
           items={[
             { value: 'all', label: t('documentWritingAll') },
             {
               value: 'litigation',
-              label: t('documentWritingLitigation'),
-              icon: <Scale className="h-3.5 w-3.5" strokeWidth={1.9} />
+              label: t('documentWritingLitigation')
             },
             {
               value: 'non-litigation',
-              label: t('documentWritingNonLitigation'),
-              icon: <ScrollText className="h-3.5 w-3.5" strokeWidth={1.9} />
+              label: t('documentWritingNonLitigation')
             },
             {
               value: 'custom',
-              label: t('documentWritingMyTemplates'),
-              icon: <User className="h-3.5 w-3.5" strokeWidth={1.9} />
+              label: t('documentWritingMyTemplates')
             }
           ]}
           onChange={onCategoryChange}
           ariaLabel={t('documentWritingTemplateLibrary')}
-          className="grid grid-cols-2 gap-1 rounded-[10px] border border-[var(--ds-sidebar-row-ring)] bg-[color-mix(in_srgb,var(--ds-sidebar-field-bg)_84%,transparent)] p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.62)] dark:bg-white/[0.035] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]"
-          buttonClassName="group inline-flex min-h-[30px] w-full items-center justify-center gap-1.5 whitespace-nowrap rounded-[7px] px-2.5 py-1 text-[12px] font-medium"
-          indicatorClassName="rounded-[7px] bg-[var(--ds-sidebar-field-focus)] shadow-[0_1px_3px_rgba(15,23,42,0.07),inset_0_0_0_1px_var(--ds-sidebar-row-ring),inset_0_1px_0_rgba(255,255,255,0.78)] dark:bg-white/[0.09]"
+          className="grid grid-cols-4 gap-0.5 rounded-[8px] border border-[var(--ds-sidebar-row-ring)] bg-[color-mix(in_srgb,var(--ds-sidebar-field-bg)_84%,transparent)] p-0.5"
+          buttonClassName="group inline-flex h-6 w-full items-center justify-center whitespace-nowrap rounded-[6px] px-1 text-[11px] font-medium"
+          indicatorClassName="rounded-[6px] bg-[var(--ds-sidebar-field-focus)] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)]"
           activeClassName="text-[#182230] dark:text-white"
           inactiveClassName="text-[#5c6675] hover:text-[#1f2733] dark:text-white/58 dark:hover:text-white/88"
         />
@@ -150,7 +148,7 @@ export function DocumentTemplateLibrary({
             </p>
           </div>
         ) : (
-          <div data-control-hover-root className="grid grid-cols-2 gap-2">
+          <div data-control-hover-root className="grid grid-cols-2 gap-1">
             {filteredTemplates.map((tmpl) => {
               const isCustom = tmpl.category === 'custom' || '_isCustom' in tmpl
               return (
@@ -160,42 +158,33 @@ export function DocumentTemplateLibrary({
                     data-control-active={activeTemplateId === tmpl.id ? 'true' : undefined}
                     onClick={() => onSelectTemplate(tmpl)}
                     title={tmpl.name}
-                    className={`ds-no-drag flex min-h-[84px] w-full flex-col items-start justify-between rounded-[14px] px-3 py-3 text-left transition duration-150 ${
+                    className={`ds-no-drag flex h-8 w-full min-w-0 items-center gap-1.5 rounded-[8px] px-2 text-left transition duration-150 ${
                       activeTemplateId === tmpl.id
-                        ? 'bg-[var(--ds-sidebar-field-focus)] shadow-[0_8px_22px_rgba(65,83,112,0.08),inset_0_0_0_1px_color-mix(in_srgb,var(--ds-accent)_24%,var(--ds-sidebar-row-ring)),inset_0_1px_0_rgba(255,255,255,0.82)] dark:bg-white/[0.09] dark:shadow-[0_10px_24px_rgba(0,0,0,0.16),inset_0_0_0_1px_rgba(51,156,255,0.22)]'
-                        : 'bg-[color-mix(in_srgb,var(--ds-sidebar-field-bg)_60%,transparent)] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)] hover:-translate-y-0.5 hover:bg-[var(--ds-sidebar-field-focus)] hover:shadow-[0_8px_20px_rgba(65,83,112,0.07),inset_0_0_0_1px_var(--ds-sidebar-row-ring)] dark:hover:bg-white/[0.07]'
+                        ? 'bg-[var(--ds-sidebar-row-active)] text-[var(--ds-ink)] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)]'
+                        : 'text-[var(--ds-muted)] hover:bg-[var(--ds-sidebar-row-hover)] hover:text-[var(--ds-ink)]'
                     }`}
                   >
-                    <span className={`flex h-8 w-8 items-center justify-center rounded-[10px] ${
+                    <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-[6px] ${
                       activeTemplateId === tmpl.id
                         ? 'bg-[var(--ds-accent-soft)] text-[var(--ds-accent)]'
                         : 'bg-[var(--ds-sidebar-field-focus)] text-[var(--ds-muted)]'
                     }`}>
-                      {categoryIcons[tmpl.category] ?? <FileText className="h-4 w-4" strokeWidth={1.75} />}
+                      {categoryIcons[tmpl.category] ?? <FileText className="h-3.5 w-3.5" strokeWidth={1.75} />}
                     </span>
-                    <span className="mt-2 line-clamp-2 text-[12.5px] font-medium leading-[1.35] text-[var(--ds-ink)]">
+                    <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[var(--ds-ink)]">
                       {tmpl.name}
                     </span>
-                    {isCustom && tmpl.learningStatus === 'analyzing' && (
-                      <span className="mt-1 inline-flex items-center gap-1 text-[9.5px] text-amber-500">
+                    {isCustom && tmpl.learningStatus === 'analyzing' ? (
+                      <span className="inline-flex shrink-0 items-center gap-1 text-[10.5px] text-amber-500">
                         <Loader2 className="h-2.5 w-2.5 animate-spin" strokeWidth={2.2} />
-                        AI 分析中
+                        分析中
                       </span>
-                    )}
-                    {isCustom && tmpl.learningStatus === 'failed' && (
-                      <span
-                        className="mt-1 inline-flex items-center gap-1 text-[9.5px] text-red-400"
-                        title={tmpl.learningError || 'AI 分析失败，可重试'}
-                      >
-                        AI 分析失败
+                    ) : null}
+                    {isCustom && tmpl.learningStatus === 'failed' ? (
+                      <span className="shrink-0 text-[10.5px] text-red-400" title={tmpl.learningError || 'AI 分析失败，可重试'}>
+                        失败
                       </span>
-                    )}
-                    {isCustom && (!tmpl.learningStatus || tmpl.learningStatus === 'idle' || tmpl.learningStatus === 'done') && (
-                      <span className="mt-1 inline-flex items-center gap-1 text-[9.5px] text-[var(--ds-accent)]">
-                        <User className="h-2.5 w-2.5" strokeWidth={2.2} />
-                        自定义
-                      </span>
-                    )}
+                    ) : null}
                   </button>
                   {isCustom && tmpl.learningStatus === 'failed' && onRetryUserTemplate && (
                     <button
@@ -205,7 +194,7 @@ export function DocumentTemplateLibrary({
                         event.stopPropagation()
                         onRetryUserTemplate(tmpl.id)
                       }}
-                      className="absolute bottom-2 right-2 rounded-[7px] p-1 text-red-400 transition hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20"
+                      className="absolute right-9 top-1/2 -translate-y-1/2 rounded-[7px] p-1 text-red-400 transition hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20"
                       title={tmpl.learningError ? `重新分析：${tmpl.learningError}` : '重新分析模板'}
                       aria-label={`重新分析 ${tmpl.name}`}
                     >
@@ -221,7 +210,7 @@ export function DocumentTemplateLibrary({
                         onDeleteUserTemplate(tmpl.id)
                       }}
                       disabled={deletingTemplateId === tmpl.id}
-                      className="absolute right-2 top-2 rounded-[7px] p-1 text-[var(--ds-faint)] opacity-0 transition hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-900/20"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-[7px] p-1 text-[var(--ds-faint)] opacity-0 transition hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-900/20"
                       title={t('documentWritingDeleteTemplate')}
                     >
                       {deletingTemplateId === tmpl.id ? (

--- a/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx
@@ -158,20 +158,20 @@ export function DocumentTemplateLibrary({
                     data-control-active={activeTemplateId === tmpl.id ? 'true' : undefined}
                     onClick={() => onSelectTemplate(tmpl)}
                     title={tmpl.name}
-                    className={`ds-no-drag flex h-8 w-full min-w-0 items-center gap-1.5 rounded-[8px] px-2 text-left transition duration-150 ${
+                    className={`ds-no-drag flex h-9 w-full min-w-0 items-center gap-1.5 rounded-[8px] px-2 text-left transition duration-150 ${
                       activeTemplateId === tmpl.id
                         ? 'bg-[var(--ds-sidebar-row-active)] text-[var(--ds-ink)] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)]'
                         : 'text-[var(--ds-muted)] hover:bg-[var(--ds-sidebar-row-hover)] hover:text-[var(--ds-ink)]'
                     }`}
                   >
-                    <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-[6px] ${
+                    <span className={`flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[6px] ${
                       activeTemplateId === tmpl.id
                         ? 'bg-[var(--ds-accent-soft)] text-[var(--ds-accent)]'
                         : 'bg-[var(--ds-sidebar-field-focus)] text-[var(--ds-muted)]'
                     }`}>
-                      {categoryIcons[tmpl.category] ?? <FileText className="h-3.5 w-3.5" strokeWidth={1.75} />}
+                      {categoryIcons[tmpl.category] ?? <FileText className="h-4 w-4" strokeWidth={1.75} />}
                     </span>
-                    <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[var(--ds-ink)]">
+                    <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-[var(--ds-ink)]">
                       {tmpl.name}
                     </span>
                     {isCustom && tmpl.learningStatus === 'analyzing' ? (

--- a/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentWritingSidebarContent.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/components/document-writing/DocumentWritingSidebarContent.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { BookOpen, Clock, Database, Upload } from 'lucide-react'
+import { BookOpen, Clock, Database } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { AstryxSegmentedControl } from '../astryx/AstryxSegmentedControl'
 import { DocumentHistorySidebar } from './DocumentHistorySidebar'
@@ -12,8 +12,8 @@ export function DocumentWritingSidebarContent(): ReactElement {
   const documentWriting = useDocumentWriting()
 
   return (
-    <div className="ds-no-drag flex min-h-0 flex-1 flex-col pt-1">
-      <div className="flex items-center gap-2 px-1 pb-3">
+    <div className="ds-no-drag flex min-h-0 flex-1 flex-col pt-0">
+      <div className="flex items-center gap-2 px-1 pb-1">
         <AstryxSegmentedControl
           value={documentWriting.leftTab}
           items={[
@@ -31,7 +31,7 @@ export function DocumentWritingSidebarContent(): ReactElement {
           onChange={documentWriting.setLeftTab}
           ariaLabel={`${t('documentWritingTemplateLibrary')} / ${t('documentWritingHistory')}`}
           className="flex min-w-0 flex-1 rounded-[8px] bg-[var(--ds-sidebar-field-bg)] p-1"
-          buttonClassName="flex h-8 flex-1 items-center justify-center gap-1.5 rounded-[7px] text-[12px] font-medium"
+          buttonClassName="flex h-7 flex-1 items-center justify-center gap-1.5 rounded-[7px] text-[12px] font-medium"
           indicatorClassName="rounded-[7px] bg-ds-card shadow-sm"
           activeClassName="text-[var(--ds-ink)]"
           inactiveClassName="text-[var(--ds-muted)] hover:text-[var(--ds-ink)]"
@@ -41,7 +41,7 @@ export function DocumentWritingSidebarContent(): ReactElement {
           onClick={documentWriting.handleKnowledgeToggle}
           title={t('knowledgeBase')}
           aria-pressed={documentWriting.knowledgePanelOpen}
-          className={`astryx-button flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] border border-[var(--ds-sidebar-row-ring)] text-[12px] font-medium transition ${
+          className={`astryx-button flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-[var(--ds-sidebar-row-ring)] text-[12px] font-medium transition ${
             documentWriting.knowledgePanelOpen
               ? 'bg-ds-card text-[var(--ds-ink)] shadow-sm'
               : 'text-[var(--ds-muted)] hover:text-[var(--ds-ink)]'
@@ -59,25 +59,15 @@ export function DocumentWritingSidebarContent(): ReactElement {
               activeCategory={documentWriting.activeCategory}
               activeTemplateId={documentWriting.activeTemplateId}
               searchQuery={documentWriting.searchQuery}
-              showUserTemplates={documentWriting.showUserTemplates}
               onSelectTemplate={documentWriting.handleSelectTemplate}
               onCategoryChange={documentWriting.handleCategoryChange}
               onSearchQueryChange={documentWriting.setSearchQuery}
+              onUploadTemplate={() => documentWriting.setUploaderOpen(true)}
               onDeleteUserTemplate={(id) => void documentWriting.handleDeleteUserTemplate(id)}
               onRetryUserTemplate={(id) => void documentWriting.handleRetryTemplateLearning(id)}
               deletingTemplateId={documentWriting.deletingTemplateId}
               loadingUserTemplates={documentWriting.loadingTemplates}
             />
-            <div className="shrink-0 border-t border-[var(--ds-sidebar-divider)] px-4 py-3">
-              <button
-                type="button"
-                onClick={() => documentWriting.setUploaderOpen(true)}
-                className="flex w-full items-center justify-center gap-2 rounded-[8px] border border-[var(--ds-sidebar-row-ring)] bg-[var(--ds-sidebar-field-bg)] px-4 py-2 text-[13px] font-medium text-[var(--ds-ink)] transition hover:bg-[color-mix(in_srgb,var(--ds-sidebar-field-focus)_56%,transparent)]"
-              >
-                <Upload className="h-4 w-4" strokeWidth={1.75} />
-                <span>{t('documentWritingUploadTemplate')}</span>
-              </button>
-            </div>
           </div>
         ) : (
           <DocumentHistorySidebar

--- a/apps/desktop-legalwork/src/renderer/src/locales/en/common.json
+++ b/apps/desktop-legalwork/src/renderer/src/locales/en/common.json
@@ -1503,7 +1503,7 @@
   "appErrorReload": "Reload",
   "learningIteration": "Learning iteration",
   "learningIterationOverview": "Learning overview",
-  "learningIterationSubtitle": "Learn reusable memory and workflows from interaction evidence while idle",
+  "learningIterationSubtitle": "Reviews recent conversations and actions while idle, then turns them into reusable memories, skills, and workflows",
   "learningIterationRecordSubtitle": "A clear look at what was learned this time",
   "learningReportTitle": "Learning outcomes",
   "learningReportEyebrow": "Learning completed",

--- a/apps/desktop-legalwork/src/renderer/src/locales/zh/common.json
+++ b/apps/desktop-legalwork/src/renderer/src/locales/zh/common.json
@@ -1503,7 +1503,7 @@
   "appErrorReload": "重新加载",
   "learningIteration": "学习迭代",
   "learningIterationOverview": "学习迭代总览",
-  "learningIterationSubtitle": "在空闲时从交互证据中提炼记忆与工作方法",
+  "learningIterationSubtitle": "空闲时自动复盘最近的对话和操作，整理成可复用的记忆、Skill 与工作方法",
   "learningIterationRecordSubtitle": "用直观方式看看这次学到了什么",
   "learningReportTitle": "学习成果报告",
   "learningReportEyebrow": "本轮学习已完成",

--- a/apps/desktop-legalwork/src/renderer/src/main.tsx
+++ b/apps/desktop-legalwork/src/renderer/src/main.tsx
@@ -8,6 +8,7 @@ import './styles/write-editor.css'
 import './styles/apple-typography.css'
 import './styles/apple-liquid-glass.css'
 import './styles/knowledge-file-sidebar.css'
+import './styles/readable-font-size.css'
 import App from './App'
 import './i18n'
 

--- a/apps/desktop-legalwork/src/renderer/src/styles/readable-font-size.css
+++ b/apps/desktop-legalwork/src/renderer/src/styles/readable-font-size.css
@@ -1,0 +1,21 @@
+/*
+ * Keep LegalWork feature pages readable at Codex-like scale.
+ * Some views use fine-grained Tailwind arbitrary sizes for dense controls;
+ * normalize those small text utilities globally so every feature page starts
+ * from a consistent 14px floor without rewriting each screen one by one.
+ */
+:where(
+  .text-\[9px\],
+  .text-\[9\.5px\],
+  .text-\[10px\],
+  .text-\[10\.5px\],
+  .text-\[11px\],
+  .text-\[11\.5px\],
+  .text-\[12px\],
+  .text-\[12\.5px\],
+  .text-\[13px\],
+  .text-\[13\.5px\]
+) {
+  font-size: 14px !important;
+}
+


### PR DESCRIPTION
## Summary
- Make the document template library more compact so more templates are visible at once.
- Move template upload into the search row and reduce category filter height.
- Increase template row readability while keeping the two-column layout.
- Add a global readable font-size floor so dense LegalWork UI text uses a consistent Codex-like 14px minimum.
- Clarify the learning iteration overview subtitle for users.

## Validation
- `npx eslint src/renderer/src/components/chat/Sidebar.tsx src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx src/renderer/src/components/document-writing/DocumentWritingSidebarContent.tsx`
- `npx eslint src/renderer/src/main.tsx src/renderer/src/components/document-writing/DocumentTemplateLibrary.tsx`
