### PR TITLE
fix(agent): gracefully degrade unavailable web search

### DIFF
--- a/apps/desktop-legalwork/legalwork/src/adapters/tool/web-tool-provider.ts
+++ b/apps/desktop-legalwork/legalwork/src/adapters/tool/web-tool-provider.ts
@@ -1,5 +1,5 @@
 import type { LegalworkCapabilitiesConfig, WebCapabilityConfig } from '../../contracts/capabilities.js'
-import type { WebFetchResult, WebProvider, WebSearchResult } from '../../ports/web-provider.js'
+import type { WebFetchResult, WebProvider, WebSearchRequest, WebSearchResult } from '../../ports/web-provider.js'
 import { sourceIdFor, UnavailableWebProvider } from '../../ports/web-provider.js'
 import type { CapabilityToolProvider } from './capability-registry.js'
 import { LocalToolHost } from './local-tool-host.js'
@@ -10,6 +10,7 @@ const DEFAULT_WEB_TIMEOUT_MS = 15_000
 // 服务端搜索(deepseek-server-search)单次请求需完成 LLM 推理+多次 web search+生成，
 // 15s 频繁误杀真实搜索（search_failed/aborted），单独放宽到 60s
 const DEFAULT_SEARCH_TIMEOUT_MS = 60_000
+const DEEPSEEK_PRIMARY_SEARCH_TIMEOUT_MS = 35_000
 // Cap web_fetch at ~96KB (~24K tokens) instead of 1MB: a full page can
 // otherwise inject up to ~250K tokens into the context as a single tool
 // result and dominate turn cost, especially during research tool loops.
@@ -46,6 +47,54 @@ export type WebToolProviderOptions = {
   deepseekModel?: string
 }
 
+/**
+ * Prefer the cheap DeepSeek server-side search, but do not let a 404, timeout,
+ * empty response, or route mismatch fail the whole turn. The fallback shares
+ * one total deadline with the primary so two providers cannot multiply latency.
+ */
+export class FallbackSearchWebProvider implements WebProvider {
+  readonly id: string
+
+  constructor(
+    private readonly primary: WebProvider,
+    private readonly fallback: WebProvider,
+    private readonly primaryTimeoutMs = DEEPSEEK_PRIMARY_SEARCH_TIMEOUT_MS
+  ) {
+    this.id = `${primary.id}+${fallback.id}`
+  }
+
+  async search(request: WebSearchRequest): Promise<WebSearchResult[]> {
+    if (!this.primary.search || !this.fallback.search) {
+      throw new Error('web search fallback provider is unavailable')
+    }
+    const totalTimeoutMs = Math.max(1, request.timeoutMs ?? DEFAULT_SEARCH_TIMEOUT_MS)
+    const startedAt = Date.now()
+    const primaryBudget = Math.min(
+      totalTimeoutMs,
+      Math.max(1, Math.min(this.primaryTimeoutMs, Math.floor(totalTimeoutMs * 0.7)))
+    )
+    let primaryError = 'primary provider returned no results'
+    try {
+      const results = await searchWithDeadline(this.primary, request, primaryBudget)
+      if (results.length > 0) return results
+    } catch (error) {
+      primaryError = errorMessage(error)
+    }
+
+    const remainingMs = totalTimeoutMs - (Date.now() - startedAt)
+    if (remainingMs <= 0) {
+      throw new Error(`primary web search failed and exhausted the deadline: ${primaryError}`)
+    }
+    try {
+      const results = await searchWithDeadline(this.fallback, request, remainingMs)
+      if (results.length > 0) return results
+      throw new Error('fallback provider returned no results')
+    } catch (error) {
+      throw new Error(`web search providers failed; primary: ${primaryError}; fallback: ${errorMessage(error)}`)
+    }
+  }
+}
+
 export function buildWebToolProviders(
   config: LegalworkCapabilitiesConfig['web'] | undefined,
   options: WebToolProviderOptions = {}
@@ -76,14 +125,17 @@ export function buildWebToolProviders(
   const fetchProvider: WebProvider = options.provider ?? (web.fetchEnabled
     ? new FetchWebProvider(options.nowIso)
     : new UnavailableWebProvider(web.provider))
-  const searchProvider: WebProvider = options.provider ?? (
-    options.deepseekApiKey?.trim()
-      ? new DeepseekServerSearchProvider({
+  const deepseekSearchProvider = options.deepseekApiKey?.trim()
+    ? new DeepseekServerSearchProvider({
           apiKey: options.deepseekApiKey,
           baseUrl: options.deepseekBaseUrl,
           model: options.deepseekModel,
           nowIso: options.nowIso
         })
+    : undefined
+  const searchProvider: WebProvider = options.provider ?? (
+    deepseekSearchProvider
+      ? new FallbackSearchWebProvider(deepseekSearchProvider, anysearchProvider)
       : (!web.provider || web.provider === 'anysearch'
           ? anysearchProvider
           : new UnavailableWebProvider(web.provider))
@@ -206,12 +258,12 @@ function createSearchTool(config: WebCapabilityConfig, provider: WebProvider) {
       // 搜索超时用独立上限（服务端搜索一次请求耗时较长），与 web_fetch 的 15s 分开
       const timeoutMs = boundedInt(args.timeout_ms, DEFAULT_SEARCH_TIMEOUT_MS, 1, DEFAULT_SEARCH_TIMEOUT_MS)
       try {
-        const results = await provider.search({
+        const results = await searchWithDeadline(provider, {
           query,
           limit,
           timeoutMs,
           signal: context.abortSignal
-        })
+        }, timeoutMs)
         return {
           output: searchOutput(query, provider.id, results, telemetry({
             startedAt,
@@ -231,6 +283,38 @@ function createSearchTool(config: WebCapabilityConfig, provider: WebProvider) {
       }
     }
   })
+}
+
+async function searchWithDeadline(
+  provider: WebProvider,
+  request: WebSearchRequest,
+  timeoutMs: number
+): Promise<WebSearchResult[]> {
+  if (!provider.search) throw new Error('web search provider is unavailable')
+  if (request.signal.aborted) throw new Error('web search was aborted')
+  const controller = new AbortController()
+  let rejectDeadline: ((error: Error) => void) | undefined
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject
+  })
+  const onAbort = (): void => {
+    controller.abort()
+    rejectDeadline?.(new Error('web search was aborted'))
+  }
+  request.signal.addEventListener('abort', onAbort, { once: true })
+  const timer = setTimeout(() => {
+    controller.abort()
+    rejectDeadline?.(new Error(`web search timed out after ${timeoutMs}ms`))
+  }, timeoutMs)
+  try {
+    return await Promise.race([
+      provider.search({ ...request, timeoutMs, signal: controller.signal }),
+      deadline
+    ])
+  } finally {
+    clearTimeout(timer)
+    request.signal.removeEventListener('abort', onAbort)
+  }
 }
 
 class FetchWebProvider implements WebProvider {

--- a/apps/desktop-legalwork/legalwork/src/loop/agent-loop.ts
+++ b/apps/desktop-legalwork/legalwork/src/loop/agent-loop.ts
@@ -145,6 +145,7 @@ import {
 } from './document-task-contract.js'
 import {
   FACT_VERIFICATION_FINALIZE_TOOL_NAME,
+  buildWebSearchQuery,
   factVerificationContract,
   factVerificationInstruction,
   factVerificationProgress,
@@ -502,6 +503,10 @@ export function shouldReportToolError(toolName: string, output: unknown): boolea
   }
   if ('exit_code' in record || 'session_id' in record) return false
   return true
+}
+
+export function shouldHideRetrievalToolFailure(toolName: string): boolean {
+  return toolName === 'web_search' || toolName === 'web_fetch'
 }
 
 export function resolvePlanModeToolSpecs(
@@ -1595,7 +1600,7 @@ function documentArtifactProgressInstruction(input: {
   ].join('\n')
 }
 
-function allowedToolNamesWithGuiStateTools(
+export function allowedToolNamesWithGuiStateTools(
   allowedToolNames: readonly string[] | undefined,
   activeGoal: boolean,
   prompt = '',
@@ -1616,6 +1621,13 @@ function allowedToolNamesWithGuiStateTools(
   // catalog — otherwise the model sees the instruction but not the tool and
   // skips both template resolution and legal research.
   next.add('resolve_legal_document_template')
+  // Fresh/current-information routing later treats web_search as a required
+  // runtime capability. A restrictive Skill allowlist must not hide that same
+  // tool before CapabilityRegistry.listTools() builds the advertised catalog.
+  if (requiresWebSearch(prompt)) {
+    next.add('web_search')
+    next.add('web_fetch')
+  }
   if (requestsLocalKnowledgeRetrieval(prompt)) {
     next.add('knowledge_auto_retrieve')
     next.add('knowledge_search')
@@ -1821,6 +1833,8 @@ export class AgentLoop {
   private readonly reasoningOnlyContinuations = new Map<string, number>()
   /** One focused retry when the model announces work without performing it. */
   private readonly pendingWorkContinuations = new Map<string, number>()
+  /** Turns that must continue best-effort after web search is unavailable/exhausted. */
+  private readonly webSearchFallbackTurns = new Set<string>()
   /** Extract uploaded documents once; reuse the canonical text on every model step. */
   private readonly attachmentDocumentMapCache = new Map<string, AttachmentDocumentMap>()
   /** One transparent compact-and-retry pass when a provider still reports an oversized context. */
@@ -1900,6 +1914,7 @@ export class AgentLoop {
       }
       this.reasoningOnlyContinuations.delete(turnId)
       this.pendingWorkContinuations.delete(turnId)
+      this.webSearchFallbackTurns.delete(turnId)
       this.contextOverflowRecoveries.delete(turnId)
       this.legalResearchContinuations.delete(turnId)
       this.memoryRetrieveCache.delete(turnId)
@@ -2441,10 +2456,12 @@ export class AgentLoop {
       ? EMPTY_FACT_CONTRACT
       : factVerificationContract(routedSkillPrompt, { primaryLegalSource: this.opts.primaryLegalSource })
     const factProgress = factVerificationProgress(healed.items, turnId, factContract)
+    const webSearchFallbackActive = this.webSearchFallbackTurns.has(turnId)
     const webSearchRequired =
       !isLearningIterationThread &&
       !planTurnActive &&
       !legalResearchWorkflow &&
+      !webSearchFallbackActive &&
       requiresWebSearch(routedSkillPrompt)
     const primaryLegalDatabaseEvidenceReady = legalResearchWorkflow &&
       hasUsablePrimaryLegalDatabaseEvidence(healed.items, turnId)
@@ -2463,6 +2480,7 @@ export class AgentLoop {
       DELIVERY_QUALITY_GATES_ENABLED &&
       !planTurnActive &&
       !legalResearchPlanPending &&
+      !webSearchFallbackActive &&
       ((factContract.requiresWebEvidence &&
         !factProgress.webSearchSatisfied &&
         factProgress.webSearchAttempts < workflowAttemptLimit('evidence')) ||
@@ -2842,61 +2860,74 @@ export class AgentLoop {
     if (webSearchRequired && !factProgress.webSearchSatisfied) {
       const webSearchAvailable = toolSpecs.some((tool) => tool.name === 'web_search')
       if (!webSearchAvailable) {
-        throw new Error('This current-information request requires web_search, but the tool is unavailable.')
-      }
-      if (factProgress.webSearchAttempts >= workflowAttemptLimit('evidence')) {
-        throw new Error('web_search did not return usable results after the allowed attempts.')
-      }
-      const callId = this.opts.ids.next('call_fresh_web_search')
-      const provider = toolProviderMetadata.get('web_search')
-      const toolKind = toolKinds.get('web_search')
-      const searchArguments = { query: routedSkillPrompt, limit: 8 }
-      const call: ToolCallLike = {
-        callId,
-        toolName: 'web_search',
-        ...(provider?.providerId ? { providerId: provider.providerId } : {}),
-        toolKind,
-        arguments: searchArguments
-      }
-      const itemId = `item_tool_${turnId}_${callId}`
-      await this.opts.turns.applyItem(
-        threadId,
-        makeToolCallItem({
-          id: itemId,
-          turnId,
-          threadId,
+        this.webSearchFallbackTurns.add(turnId)
+        await this.recordPipelineStage(threadId, turnId, 'response_received', {
+          label: 'Web search unavailable; continuing best-effort',
+          requiredTool: 'web_search',
+          registryOrProviderMissing: !allowedToolNames || allowedToolNames.includes('web_search'),
+          allowedToolPolicyFiltered: Boolean(allowedToolNames && !allowedToolNames.includes('web_search')),
+          toolCatalogFingerprint: toolCatalog.fingerprint
+        })
+      } else if (factProgress.webSearchAttempts >= workflowAttemptLimit('evidence')) {
+        this.webSearchFallbackTurns.add(turnId)
+        await this.recordPipelineStage(threadId, turnId, 'response_received', {
+          label: 'Web search attempts exhausted; continuing best-effort',
+          requiredTool: 'web_search',
+          attempts: factProgress.webSearchAttempts,
+          toolCatalogFingerprint: toolCatalog.fingerprint
+        })
+      } else {
+        const callId = this.opts.ids.next('call_fresh_web_search')
+        const provider = toolProviderMetadata.get('web_search')
+        const toolKind = toolKinds.get('web_search')
+        const searchArguments = { query: buildWebSearchQuery(routedSkillPrompt), limit: 8 }
+        const call: ToolCallLike = {
           callId,
           toolName: 'web_search',
+          ...(provider?.providerId ? { providerId: provider.providerId } : {}),
           toolKind,
-          arguments: searchArguments,
-          summary: 'Runtime-prefetched current web information before answer synthesis.'
+          arguments: searchArguments
+        }
+        const itemId = `item_tool_${turnId}_${callId}`
+        await this.opts.turns.applyItem(
+          threadId,
+          makeToolCallItem({
+            id: itemId,
+            turnId,
+            threadId,
+            callId,
+            toolName: 'web_search',
+            toolKind,
+            arguments: searchArguments,
+            summary: 'Runtime-prefetched current web information before answer synthesis.'
+          })
+        )
+        await this.opts.events.record({
+          kind: 'tool_call_ready',
+          threadId,
+          turnId,
+          itemId,
+          callId,
+          toolName: 'web_search',
+          readyCount: 1
         })
-      )
-      await this.opts.events.record({
-        kind: 'tool_call_ready',
-        threadId,
-        turnId,
-        itemId,
-        callId,
-        toolName: 'web_search',
-        readyCount: 1
-      })
-      const dispatched = await this.dispatchToolCalls({
-        calls: [call],
-        threadId,
-        turnId,
-        workspace: thread?.workspace ?? '',
-        threadMode: effectiveMode,
-        activePlanContext,
-        modelCapabilities,
-        activeSkillIds: skillResolution.activeSkillIds,
-        allowedToolNames,
-        toolProviderKinds: new Map(tools.map((tool) => [tool.name, tool.providerKind])),
-        approvalPolicy,
-        signal
-      })
-      if (dispatched === 'aborted') return 'aborted'
-      return 'continue'
+        const dispatched = await this.dispatchToolCalls({
+          calls: [call],
+          threadId,
+          turnId,
+          workspace: thread?.workspace ?? '',
+          threadMode: effectiveMode,
+          activePlanContext,
+          modelCapabilities,
+          activeSkillIds: skillResolution.activeSkillIds,
+          allowedToolNames,
+          toolProviderKinds: new Map(tools.map((tool) => [tool.name, tool.providerKind])),
+          approvalPolicy,
+          signal
+        })
+        if (dispatched === 'aborted') return 'aborted'
+        return 'continue'
+      }
     }
 
     if (caseResearchRequiredToolName) {
@@ -3267,6 +3298,9 @@ export class AgentLoop {
     const pendingWorkRecoveryInstruction = (this.pendingWorkContinuations.get(turnId) ?? 0) > 0
       ? '上一次回复只说明了准备做什么。现在不要再预告步骤或新增检索，直接输出已经能够完成的最终正文或结果。'
       : undefined
+    const webSearchFallbackInstruction = this.webSearchFallbackTurns.has(turnId)
+      ? '本轮实时网页检索不可用或未取得可用结果。不要输出“web_search unavailable”、工具错误或阻塞说明；直接基于已有对话、附件和已取得资料完成用户任务。仅对确实依赖实时信息且无法确认的内容简短标注“待实时核验”，不得因此吞掉其余可交付结果。'
+      : undefined
     const deliveryFailureInstruction = deliveryAttemptsExhausted
       ? '文件生成工具已达到有界重试次数。立即停止重试，输出可用正文或大纲，并简洁说明未能生成请求的文件。'
       : undefined
@@ -3321,6 +3355,7 @@ export class AgentLoop {
       ...(researchStageInstruction ? [researchStageInstruction] : []),
       ...(reasoningOnlyRecoveryInstruction ? [reasoningOnlyRecoveryInstruction] : []),
       ...(pendingWorkRecoveryInstruction ? [pendingWorkRecoveryInstruction] : []),
+      ...(webSearchFallbackInstruction ? [webSearchFallbackInstruction] : []),
       ...(deliveryFailureInstruction ? [deliveryFailureInstruction] : []),
       ...(turnBudgetWrapUp ? [TURN_BUDGET_WRAPUP_INSTRUCTION] : []),
       // 工具目录漂移提示只存在单步、下一步即消失，放易变段（history 后），
@@ -4421,31 +4456,46 @@ export class AgentLoop {
     call: ToolCallLike,
     result: ToolHostResult
   ): Promise<void> {
+    let persistedResult: ToolHostResult = result
+    if (
+      result.item.kind === 'tool_result' &&
+      result.item.isError === true &&
+      shouldHideRetrievalToolFailure(call.toolName)
+    ) {
+      persistedResult = {
+        ...result,
+        item: {
+          ...result.item,
+          isError: false,
+          status: 'completed'
+        }
+      }
+    }
     // 工具调用返回错误 → 通过 onToolError 回调上报（仅工具名+错误摘要，
     // 不含工具参数/对话内容，避免敏感信息外传）。
-    if (result.item.kind === 'tool_result' && result.item.isError === true && shouldReportToolError(call.toolName, result.item.output)) {
+    if (persistedResult.item.kind === 'tool_result' && persistedResult.item.isError === true && shouldReportToolError(call.toolName, persistedResult.item.output)) {
       try {
         this.opts.onToolError?.({
           threadId,
           turnId,
           toolName: call.toolName,
-          error: extractToolError(result.item.output)
+          error: extractToolError(persistedResult.item.output)
         })
       } catch {
         // 上报失败绝不影响 agent 主流程
       }
     }
     await this.opts.turns.updateItem(threadId, `item_tool_${turnId}_${call.callId}`, {
-      status: result.item.kind === 'tool_result' && result.item.isError ? 'failed' : 'completed',
+      status: persistedResult.item.kind === 'tool_result' && persistedResult.item.isError ? 'failed' : 'completed',
       finishedAt: this.opts.nowIso()
     } as Partial<TurnItem>)
-    if (result.item.kind === 'tool_result' && !result.item.isError && RESUMABLE_RESULT_TOOL_NAMES.has(call.toolName)) {
+    if (persistedResult.item.kind === 'tool_result' && !persistedResult.item.isError && RESUMABLE_RESULT_TOOL_NAMES.has(call.toolName)) {
       // 只对可续读工具（read/grep/bash）做持久化裁剪；无法续读的工具保留完整结果，
       // 避免模型永远看不到大结果的中间段。
-      result.item.output = pruneToolResultOutput(result.item.output)
+      persistedResult.item.output = pruneToolResultOutput(persistedResult.item.output)
     }
-    await this.opts.turns.applyItem(threadId, result.item)
-    await this.afterToolResultPersisted(threadId, turnId, call, result)
+    await this.opts.turns.applyItem(threadId, persistedResult.item)
+    await this.afterToolResultPersisted(threadId, turnId, call, persistedResult)
   }
 
   private async afterToolResultPersisted(

--- a/apps/desktop-legalwork/legalwork/src/loop/fact-verification.ts
+++ b/apps/desktop-legalwork/legalwork/src/loop/fact-verification.ts
@@ -84,6 +84,41 @@ export function requiresWebSearch(prompt: string): boolean {
   return /(?:法考|公考|国考|省考|公务员).{0,12}(?:政策|公告|通知|考纲|大纲|报名条件|报名时间|考试时间|考察要素|考查要素|考察内容|考查内容)|(?:政策|公告|通知|考纲|大纲|报名条件|报名时间|考试时间|考察要素|考查要素|考察内容|考查内容).{0,12}(?:法考|公考|国考|省考|公务员)/.test(compact)
 }
 
+/**
+ * Turn routing may prepend an earlier substantive request and append control
+ * sections such as "后续要求" / "当前追问". Those sections are useful to the
+ * model but make poor search queries and have previously been sent verbatim to
+ * providers. Keep the substantive anchor, remove runtime markup, and apply a
+ * conservative length cap before deterministic runtime-prefetch.
+ */
+export function buildWebSearchQuery(prompt: string, maxChars = 240): string {
+  const normalized = prompt
+    .replace(/<knowledge_context>[\s\S]*?<\/knowledge_context>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\r\n?/g, '\n')
+  const anchor = normalized.split(/\n\s*(?:后续要求|当前追问)\s*[：:]/)[0] ?? ''
+  const cleaned = anchor
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !/^(?:后续要求|当前追问|runtime|system|assistant)\s*[：:]/i.test(line))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  const fallback = normalized.replace(/\s+/g, ' ').trim()
+  const query = cleaned || fallback
+  if (query.length <= maxChars) return query
+  const clipped = query.slice(0, Math.max(1, maxChars))
+  const sentenceEnd = Math.max(
+    clipped.lastIndexOf('。'),
+    clipped.lastIndexOf('；'),
+    clipped.lastIndexOf('？'),
+    clipped.lastIndexOf('?')
+  )
+  return (sentenceEnd >= Math.floor(maxChars / 2)
+    ? clipped.slice(0, sentenceEnd + 1)
+    : clipped).trim()
+}
+
 export function factVerificationContract(
   prompt: string,
   options?: { primaryLegalSource?: LegalResearchPrimarySource }

--- a/apps/desktop-legalwork/legalwork/tests/loop.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/loop.test.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_MAX_AGENT_LOOP_STEPS,
   MAX_AGENT_LOOP_STEPS_ENV,
   MAX_AGENT_LOOP_STEPS_ENV_CAP,
+  allowedToolNamesWithGuiStateTools,
   assistantAnnouncesPendingToolWork,
   attachResolvedAttachmentContextToHistory,
   deliveredWordLocationAnswer,
@@ -27,12 +28,17 @@ import {
   resolveMaxAgentLoopSteps,
   isStalledTurnProgress,
   shouldReportToolError,
+  shouldHideRetrievalToolFailure,
   skillRoutingPrompt,
   turnProgressSnapshot,
   turnBudgetCompletionToolSpecs
 } from '../src/loop/agent-loop.js'
 import { resolveModelContextProfile } from '../src/loop/model-context-profile.js'
-import { requiresFreshWebSearch, requiresWebSearch } from '../src/loop/fact-verification.js'
+import {
+  buildWebSearchQuery,
+  requiresFreshWebSearch,
+  requiresWebSearch
+} from '../src/loop/fact-verification.js'
 import { makeAssistantTextItem, makeToolCallItem, makeToolResultItem, makeUserItem } from '../src/domain/item.js'
 import { createThreadRecord } from '../src/domain/thread.js'
 import { createImmutablePrefix, setSystemPrompt } from '../src/cache/immutable-prefix.js'
@@ -504,6 +510,33 @@ describe('AgentLoop', () => {
     expect(shouldReportToolError('mcp_yuandian_case_search', {
       error: 'MCP arguments do not match the schema'
     })).toBe(false)
+  })
+
+  it('keeps required web tools advertised through a restrictive Skill allowlist', () => {
+    const allowed = allowedToolNamesWithGuiStateTools(
+      ['read'],
+      false,
+      '帮我网上搜索一下最新规定',
+      ['restrictive-test-skill']
+    )
+
+    expect(allowed).toEqual(expect.arrayContaining(['read', 'web_search', 'web_fetch']))
+    expect(shouldHideRetrievalToolFailure('web_search')).toBe(true)
+    expect(shouldHideRetrievalToolFailure('web_fetch')).toBe(true)
+    expect(shouldHideRetrievalToolFailure('read')).toBe(false)
+  })
+
+  it('builds a bounded search query without routed follow-up control text', () => {
+    const prompt = [
+      '2026年法考报名政策和考试时间',
+      '',
+      '后续要求：不执行，并总结这个报告有什么作用',
+      '',
+      '当前追问：全部删去吧'
+    ].join('\n')
+
+    expect(buildWebSearchQuery(prompt)).toBe('2026年法考报名政策和考试时间')
+    expect(buildWebSearchQuery(`最新政策 ${'很长'.repeat(200)}`).length).toBeLessThanOrEqual(240)
   })
 
   it('falls back to a bounded visible notice at the loop step limit', async () => {
@@ -5505,6 +5538,71 @@ describe('FileSessionStore', () => {
     expect(items.some((item) =>
       item.kind === 'tool_result' && item.toolName === 'web_search'
     )).toBe(true)
+  })
+
+  it('continues without a user-visible error when required web_search is not registered', async () => {
+    let modelRequests = 0
+    const h = makeHarness({
+      provider: 'missing-web-search-fallback',
+      model: 'missing-web-search-fallback',
+      async *stream(request): AsyncIterable<ModelStreamChunk> {
+        modelRequests += 1
+        expect(request.contextInstructions?.join('\n')).toContain('不得因此吞掉其余可交付结果')
+        yield { kind: 'assistant_text_delta', text: '先根据现有材料完成分析；实时变化部分标记为待核验。' }
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }, { tools: [] })
+    await bootstrapThread(h, { request: { prompt: '帮我网上搜索一下最新司法解释并分析案件' } })
+
+    expect(await h.loop.runTurn(h.threadId, h.turnId)).toBe('completed')
+    expect(modelRequests).toBe(1)
+    const events = await h.sessionStore.loadEventsSince(h.threadId, 0)
+    expect(events.some((event) => event.kind === 'turn_failed')).toBe(false)
+    expect(events.some((event) =>
+      event.kind === 'pipeline_stage' &&
+      event.details?.label === 'Web search unavailable; continuing best-effort'
+    )).toBe(true)
+  })
+
+  it('keeps failed web_search attempts out of the visible error count and still answers', async () => {
+    let searchAttempts = 0
+    const webSearch = LocalToolHost.defineTool({
+      name: 'web_search',
+      description: 'Search current web information.',
+      inputSchema: {
+        type: 'object',
+        properties: { query: { type: 'string' }, limit: { type: 'number' } },
+        required: ['query'],
+        additionalProperties: false
+      },
+      policy: 'auto',
+      execute: async () => {
+        searchAttempts += 1
+        return {
+          output: { error: { code: 'search_failed', message: 'HTTP 404 NOT_FOUND' } },
+          isError: true
+        }
+      }
+    })
+    const h = makeHarness({
+      provider: 'failed-web-search-fallback',
+      model: 'failed-web-search-fallback',
+      async *stream(request): AsyncIterable<ModelStreamChunk> {
+        expect(request.contextInstructions?.join('\n')).toContain('待实时核验')
+        yield { kind: 'assistant_text_delta', text: '已完成不依赖实时检索的部分。' }
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }, { tools: [webSearch] })
+    await bootstrapThread(h, { request: { prompt: '查询最新法考政策并给出准备建议' } })
+
+    expect(await h.loop.runTurn(h.threadId, h.turnId)).toBe('completed')
+    expect(searchAttempts).toBeGreaterThan(0)
+    const items = await h.sessionStore.loadItems(h.threadId)
+    const searchResults = items.filter((item) =>
+      item.kind === 'tool_result' && item.toolName === 'web_search'
+    )
+    expect(searchResults.length).toBeGreaterThan(0)
+    expect(searchResults.every((item) => item.kind === 'tool_result' && item.isError !== true)).toBe(true)
   })
 
   it('keeps mandatory searches isolated across three concurrent conversations', async () => {

--- a/apps/desktop-legalwork/legalwork/tests/web-tool-provider.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/web-tool-provider.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { CapabilityRegistry } from '../src/adapters/tool/capability-registry.js'
 import { LocalToolHost } from '../src/adapters/tool/local-tool-host.js'
-import { buildWebToolProviders } from '../src/adapters/tool/web-tool-provider.js'
+import {
+  FallbackSearchWebProvider,
+  buildWebToolProviders
+} from '../src/adapters/tool/web-tool-provider.js'
 import {
   buildRuntimeCapabilityManifest,
   LegalworkCapabilitiesConfig
 } from '../src/contracts/capabilities.js'
 import { modelCapabilitiesForModel } from '../src/loop/model-context-profile.js'
 import { DeterministicWebProvider } from '../src/ports/web-provider.js'
+import type { WebProvider } from '../src/ports/web-provider.js'
 import type { ToolHostContext } from '../src/ports/tool-host.js'
 
 function buildContext(): ToolHostContext {
@@ -48,6 +52,92 @@ function deterministicProvider() {
 }
 
 describe('Web tool provider', () => {
+  it('falls back after the primary search provider fails', async () => {
+    const calls: string[] = []
+    const primary: WebProvider = {
+      id: 'primary',
+      async search() {
+        calls.push('primary')
+        throw new Error('HTTP 404 NOT_FOUND')
+      }
+    }
+    const fallback: WebProvider = {
+      id: 'fallback',
+      async search() {
+        calls.push('fallback')
+        return [{
+          sourceId: 'fallback-source',
+          url: 'https://example.test/fallback',
+          title: 'Fallback result',
+          snippet: 'Recovered search result',
+          provider: 'fallback',
+          rank: 1,
+          retrievedAt: '2026-08-21T00:00:00.000Z'
+        }]
+      }
+    }
+    const provider = new FallbackSearchWebProvider(primary, fallback, 10)
+
+    const results = await provider.search({
+      query: 'current legal policy',
+      limit: 5,
+      timeoutMs: 100,
+      signal: new AbortController().signal
+    })
+
+    expect(calls).toEqual(['primary', 'fallback'])
+    expect(results[0]?.provider).toBe('fallback')
+  })
+
+  it('bounds a hanging primary provider before using the fallback', async () => {
+    const primary: WebProvider = {
+      id: 'hanging-primary',
+      async search() {
+        return await new Promise(() => undefined)
+      }
+    }
+    const fallback: WebProvider = {
+      id: 'fast-fallback',
+      async search() {
+        return [{
+          sourceId: 'fast-source',
+          url: 'https://example.test/fast',
+          title: 'Fast fallback',
+          snippet: '',
+          provider: 'fast-fallback',
+          rank: 1,
+          retrievedAt: '2026-08-21T00:00:00.000Z'
+        }]
+      }
+    }
+    const provider = new FallbackSearchWebProvider(primary, fallback, 10)
+    const startedAt = Date.now()
+
+    const results = await provider.search({
+      query: 'bounded search',
+      limit: 5,
+      timeoutMs: 100,
+      signal: new AbortController().signal
+    })
+
+    expect(Date.now() - startedAt).toBeLessThan(500)
+    expect(results[0]?.provider).toBe('fast-fallback')
+  })
+
+  it('builds DeepSeek search with an AnySearch fallback provider', () => {
+    const config = LegalworkCapabilitiesConfig.parse({
+      web: { enabled: true, searchEnabled: true }
+    })
+    const built = buildWebToolProviders(config.web, {
+      deepseekApiKey: 'sk-test',
+      deepseekBaseUrl: 'https://api.deepseek.com',
+      deepseekModel: 'deepseek-v4-flash'
+    })
+
+    expect(built.searchAvailable).toBe(true)
+    expect(built.provider).toBe('deepseek-server-search+anysearch')
+  })
+
   it('does not advertise web tools when web access is disabled', async () => {
     const config = LegalworkCapabilitiesConfig.parse({})
     const built = buildWebToolProviders(config.web, { provider: deterministicProvider() })


### PR DESCRIPTION
## 问题

DeepSeek 模型处理需要实时信息的请求时，`web_search` 可能被 Skill 工具白名单过滤，或搜索服务发生 404、超时、空结果。Agent loop 随后直接抛出 `This current-information request requires web_search, but the tool is unavailable.`，导致整轮失败并向用户展示红色错误。

## 修复

- 对需要实时检索的请求，确保限制性 Skill 白名单始终保留 `web_search` / `web_fetch`。
- DeepSeek 服务端搜索在 404、超时或空结果时自动回退到 AnySearch，并共享总超时预算。
- 运行时预检索使用清洗、限长后的查询，避免把路由控制文本和整段长提示词直接发送给搜索服务。
- 搜索工具缺失或有界重试耗尽时继续生成可交付答案；仅将确实依赖实时信息的部分标为“待实时核验”。
- `web_search` / `web_fetch` 失败仍保留内部结构化诊断，但不再显示为用户可见的红色工具错误；其他模型同样适用。

## 验证

- Runtime targeted tests: 149 passed
- Runtime full suite: 844 passed；1 个既有文件队列时序测试首次运行失败，隔离重跑 32/32 passed
- Runtime typecheck: passed
- Runtime build: passed
- Desktop typecheck: passed
- Desktop build: passed
- Desktop full suite: 1172 passed；7 个与本改动无关的更新器/技能扫描/连接超时测试失败

Fixes the web-search failure path described in the v0.3.24-v0.3.26 bug report.