### PR TITLE
fix: address v0.3.28 reported failures

### DIFF
--- a/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-bash-tool.ts
+++ b/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-bash-tool.ts
@@ -528,7 +528,14 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
         }
         const session = sessionById(args.session_id)
         if (!session) {
-          return { output: { error: 'bash session not found', session_id: args.session_id ?? null }, isError: true }
+          return {
+            output: {
+              error: 'bash session expired or the runtime restarted; rerun the original command with action="run"',
+              code: 'bash_session_not_found',
+              session_id: args.session_id ?? null
+            },
+            isError: true
+          }
         }
         if (action === 'write') {
           if (session.status !== 'running') {

--- a/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-file-tools.ts
+++ b/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-file-tools.ts
@@ -63,7 +63,7 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
   const writeFileOp = _options.operations?.writeFile ?? defaultEditLocalToolOperations.writeFile!
   return LocalToolHost.defineTool({
     name: 'edit',
-    description: 'Edit a local filesystem file using exact text replacement. Relative paths resolve against the current workspace; absolute paths may point anywhere on the computer. Supports multiple disjoint edits in one call.',
+    description: 'Edit a local filesystem file using exact text replacement. You MUST first read this exact path in the current turn and copy every oldText value exactly from that read output. If the file changed or the read was from an earlier turn, read it again before editing. Relative paths resolve against the current workspace; absolute paths may point anywhere on the computer. Supports multiple disjoint edits in one call.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/apps/desktop-legalwork/legalwork/src/knowledge/knowledge-store.test.ts
+++ b/apps/desktop-legalwork/legalwork/src/knowledge/knowledge-store.test.ts
@@ -122,6 +122,27 @@ describe('FileKnowledgeStore', () => {
     }
   })
 
+  it('omits dependency and Python environment directories from the managed tree', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'legalwork-kb-tree-skip-'))
+    const indexRoot = join(root, 'index')
+    try {
+      const store = new FileKnowledgeStore({ rootDir: indexRoot, sourceRoots: [] })
+      await store.writeFile({ path: 'matter/brief.md', content: '案情摘要', encoding: 'utf8' })
+      await mkdir(join(indexRoot, 'files', '.venv', 'Lib', 'site-packages'), { recursive: true })
+      await writeFile(join(indexRoot, 'files', '.venv', 'Lib', 'site-packages', 'noise.md'), 'noise', 'utf8')
+      await mkdir(join(indexRoot, 'files', 'node_modules', 'package'), { recursive: true })
+      await writeFile(join(indexRoot, 'files', 'node_modules', 'package', 'noise.md'), 'noise', 'utf8')
+
+      const tree = await store.tree()
+
+      expect(tree.map((node) => node.name)).toContain('matter')
+      expect(tree.map((node) => node.name)).not.toContain('.venv')
+      expect(tree.map((node) => node.name)).not.toContain('node_modules')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('syncs local files and searches Chinese legal terms', async () => {
     const root = await mkdtemp(join(tmpdir(), 'legalwork-kb-'))
     const sourceRoot = join(root, 'knowledge-base')

--- a/apps/desktop-legalwork/legalwork/src/knowledge/knowledge-store.ts
+++ b/apps/desktop-legalwork/legalwork/src/knowledge/knowledge-store.ts
@@ -100,7 +100,21 @@ const MANAGED_FILE_EXTENSIONS = new Set([
   '.rar',
   '.7z'
 ])
-const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', 'out', '.next', '.vite'])
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.vite',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.tox'
+])
 export const DEFAULT_KNOWLEDGE_SYNC_MAX_FILES = 20_000
 export const AUTO_SQLITE_FILE_THRESHOLD = 2_000
 const CHUNK_SIZE = 2400
@@ -275,6 +289,7 @@ export class FileKnowledgeStore implements KnowledgeStore {
       if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
       return a.name.localeCompare(b.name)
     })) {
+      if (entry.isDirectory() && SKIP_DIRS.has(entry.name)) continue
       const fullPath = join(dir, entry.name)
       const relativePath = relative(this.managedRoot, fullPath)
       if (entry.isDirectory()) {

--- a/apps/desktop-legalwork/legalwork/src/loop/agent-loop.ts
+++ b/apps/desktop-legalwork/legalwork/src/loop/agent-loop.ts
@@ -465,6 +465,9 @@ function extractToolError(output: unknown): string {
  */
 export function shouldReportToolError(toolName: string, output: unknown): boolean {
   const message = extractToolError(output)
+  const code = output && typeof output === 'object' && typeof (output as Record<string, unknown>).code === 'string'
+    ? (output as Record<string, string>).code
+    : ''
   // A model may serialize a stale or hallucinated tool name even though the
   // current request's schema did not advertise it. The tool result already
   // tells the model to use the active catalog; this is a recoverable model
@@ -472,6 +475,11 @@ export function shouldReportToolError(toolName: string, output: unknown): boolea
   if (/not advertised by active tool policy|not advertised in this turn context|unknown tool:/i.test(message)) {
     return false
   }
+  // These guards intentionally reject stale model actions and tell the model
+  // how to recover. They protect user files/sessions; they do not indicate a
+  // product incident and must not create automatic GitHub reports.
+  if (code === 'read_before_edit_required' || /read-before-edit guard blocked edit/i.test(message)) return false
+  if (toolName === 'bash' && (code === 'bash_session_not_found' || /bash session (?:not found|expired)/i.test(message))) return false
   // Remote pages, search providers, and legal databases routinely reject an
   // individual URL/query. Those failures are returned to the model so it can
   // try another source; they are not evidence that the desktop runtime broke.

--- a/apps/desktop-legalwork/legalwork/tests/builtin-tools.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/builtin-tools.test.ts
@@ -504,6 +504,19 @@ describe('Legalwork built-in tools', () => {
     expect(String(polled.output)).toContain('done')
   })
 
+  it('tells the agent how to recover when a bash session expired', async () => {
+    const output = await executeTool(host, workspace, 'bash', {
+      action: 'poll',
+      session_id: 'missing-session'
+    })
+
+    expect(output).toMatchObject({
+      code: 'bash_session_not_found',
+      session_id: 'missing-session'
+    })
+    expect(String(output.error)).toContain('rerun the original command')
+  })
+
   it('includes the active shell in bash partial updates', async () => {
     const updates: TurnItem[] = []
     const result = await host.execute(

--- a/apps/desktop-legalwork/legalwork/tests/loop.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/loop.test.ts
@@ -510,6 +510,13 @@ describe('AgentLoop', () => {
     expect(shouldReportToolError('mcp_yuandian_case_search', {
       error: 'MCP arguments do not match the schema'
     })).toBe(false)
+    expect(shouldReportToolError('edit', {
+      error: 'read-before-edit guard blocked edit for brief.md. Read the current file contents in this turn.'
+    })).toBe(false)
+    expect(shouldReportToolError('bash', {
+      error: 'bash session expired or the runtime restarted; rerun the original command with action="run"',
+      code: 'bash_session_not_found'
+    })).toBe(false)
   })
 
   it('keeps required web tools advertised through a restrictive Skill allowlist', () => {

--- a/apps/desktop-legalwork/src/main/index.ts
+++ b/apps/desktop-legalwork/src/main/index.ts
@@ -81,7 +81,13 @@ import {
 import { webhookUrl } from './claw-runtime-helpers'
 import { isLegalworkHealthResponseBody } from './legalwork-health'
 import { FingerprintedSingleFlight } from './runtime/fingerprinted-single-flight'
+import { recoverUnhealthyOwnedRuntime } from './runtime/unhealthy-owned-runtime'
+import { isRuntimeProbePath } from './runtime/runtime-probe-path'
 import { continueAppQuitAfterCleanup } from './continue-app-quit'
+import {
+  ChildProcessGoneReportPolicy,
+  shouldReportRenderProcessGone
+} from './process-gone-policy'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const HIDDEN_START_ARG = '--hidden'
@@ -636,12 +642,21 @@ async function ensureRuntimeOnce(settings: AppSettingsV1): Promise<void> {
 async function ensureLegalworkRuntime(settings: AppSettingsV1): Promise<void> {
   const runtime = getLegalworkRuntimeSettings(settings)
   const hasModelAuth = hasConfiguredModelAuth(settings)
+  const adapter = legalworkRuntimeAdapter
 
   const healthy = await waitForLegalworkHealth(settings, RUNTIME_EXISTING_HEALTH_FAST_MS)
   if (healthy) {
     const threadApi = await probeThreadApi(settings)
     if (threadApi.ok) return
-    throw runtimeJsonError(threadApi.error, threadApi.message)
+    // An externally managed runtime must not be terminated by this app. An
+    // owned child, however, is unhealthy if its core API fails even while the
+    // shallow /health endpoint still responds, so let it enter recovery below.
+    if (!adapter.isChildRunning()) {
+      throw runtimeJsonError(threadApi.error, threadApi.message)
+    }
+    logWarn('runtime-ensure', 'Owned Legalwork child passed health but failed the thread API probe.', {
+      message: threadApi.message
+    })
   }
 
   if (!hasModelAuth) {
@@ -657,7 +672,17 @@ async function ensureLegalworkRuntime(settings: AppSettingsV1): Promise<void> {
     )
   }
 
-  const adapter = legalworkRuntimeAdapter
+  const ownedRecovery = await recoverUnhealthyOwnedRuntime(adapter, async () => {
+    const lateHealthy = await waitForLegalworkHealth(settings, RUNTIME_PORT_CONFLICT_HEALTH_RECHECK_MS)
+    if (!lateHealthy) return false
+    return (await probeThreadApi(settings)).ok
+  })
+  if (ownedRecovery === 'became-healthy') return
+  if (ownedRecovery === 'stopped') {
+    logWarn('runtime-ensure', 'Stopped an owned Legalwork child after its health probe failed.', {
+      port: runtime.port
+    })
+  }
   const reclaim = await adapter.reclaimPort(runtime.port)
   if (!reclaim.ok) {
     const lateHealthy = await waitForLegalworkHealth(settings, RUNTIME_PORT_CONFLICT_HEALTH_RECHECK_MS)
@@ -932,25 +957,6 @@ async function restartManagedRuntimeForMcpConfigChange(settings: AppSettingsV1):
   }
 }
 
-/**
- * 健康/探测类端点在 runtime 启动竞态（服务尚未就绪或正在重启）期间失败是预期行为，
- * 用路径白名单 + 仅 GET 判定，命中时只记录 warn 日志、不触发错误上报，避免刷屏；
- * 业务写入（POST）失败仍正常上报。
- */
-function isRuntimeProbePath(pathAndQuery: string): boolean {
-  const pathname = pathAndQuery.split('?')[0] ?? ''
-  return (
-    pathname === '/health' ||
-    pathname === '/v1/runtime/info' ||
-    pathname === '/v1/runtime/tools' ||
-    pathname === '/v1/threads' ||
-    pathname.startsWith('/v1/threads/') ||
-    pathname === '/v1/memory' ||
-    pathname === '/v1/usage' ||
-    pathname.startsWith('/data-compliance/')
-  )
-}
-
 async function runtimeRequest(
   settings: AppSettingsV1,
   pathAndQuery: string,
@@ -974,6 +980,7 @@ async function runtimeRequest(
 }
 
 function registerGlobalErrorHandlers(): void {
+  const childProcessGonePolicy = new ChildProcessGoneReportPolicy()
   const report = (input: { category: string; message: string; stack?: string }): void => {
     // logError writes the local log AND (via the injected reporter) triggers
     // the silent error report. Never let this path itself throw.
@@ -1006,6 +1013,10 @@ function registerGlobalErrorHandlers(): void {
   })
 
   app.on('render-process-gone', (_event, _webContents, details) => {
+    if (!shouldReportRenderProcessGone(details, isQuitting)) {
+      logWarn('render-process-gone', 'Renderer process exited without an actionable crash.', details)
+      return
+    }
     report({
       category: 'render-process-gone',
       message: `${details.reason} (exit code ${details.exitCode})`
@@ -1013,6 +1024,10 @@ function registerGlobalErrorHandlers(): void {
   })
 
   app.on('child-process-gone', (_event, details) => {
+    if (!childProcessGonePolicy.shouldReport(details, isQuitting)) {
+      logWarn('child-process-gone', 'Child process exited without a persistent actionable crash.', details)
+      return
+    }
     report({
       category: 'child-process-gone',
       message: `${details.type} ${details.reason} (${details.exitCode ?? ''})`

--- a/apps/desktop-legalwork/src/main/process-gone-policy.test.ts
+++ b/apps/desktop-legalwork/src/main/process-gone-policy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ChildProcessGoneReportPolicy,
+  shouldReportRenderProcessGone
+} from './process-gone-policy'
+
+describe('process-gone reporting policy', () => {
+  it('does not report intentional renderer termination or app shutdown', () => {
+    expect(shouldReportRenderProcessGone({ reason: 'killed', exitCode: -1073741510 }, false)).toBe(false)
+    expect(shouldReportRenderProcessGone({ reason: 'crashed', exitCode: 1 }, true)).toBe(false)
+    expect(shouldReportRenderProcessGone({ reason: 'crashed', exitCode: 1 }, false)).toBe(true)
+  })
+
+  it('reports GPU crashes only after a repeated burst', () => {
+    const policy = new ChildProcessGoneReportPolicy(3, 60_000)
+    const details = { type: 'GPU', reason: 'crashed', exitCode: 34 }
+
+    expect(policy.shouldReport(details, false, 1_000)).toBe(false)
+    expect(policy.shouldReport(details, false, 2_000)).toBe(false)
+    expect(policy.shouldReport(details, false, 3_000)).toBe(true)
+  })
+
+  it('still reports non-GPU child crashes immediately', () => {
+    const policy = new ChildProcessGoneReportPolicy()
+    expect(policy.shouldReport({ type: 'Utility', reason: 'crashed', exitCode: 1 }, false)).toBe(true)
+  })
+})

--- a/apps/desktop-legalwork/src/main/process-gone-policy.ts
+++ b/apps/desktop-legalwork/src/main/process-gone-policy.ts
@@ -1,0 +1,36 @@
+export type ProcessGoneDetails = {
+  reason: string
+  exitCode?: number
+  type?: string
+}
+
+export function shouldReportRenderProcessGone(
+  details: ProcessGoneDetails,
+  isQuitting: boolean
+): boolean {
+  if (isQuitting) return false
+  return details.reason !== 'clean-exit' && details.reason !== 'killed'
+}
+
+/** Electron normally restarts an isolated GPU process crash. Report only a
+ * repeated crash burst, which is actionable evidence of a persistent fault. */
+export class ChildProcessGoneReportPolicy {
+  private gpuCrashTimes: number[] = []
+
+  constructor(
+    private readonly gpuCrashThreshold = 3,
+    private readonly gpuCrashWindowMs = 60_000
+  ) {}
+
+  shouldReport(details: ProcessGoneDetails, isQuitting: boolean, now = Date.now()): boolean {
+    if (isQuitting) return false
+    if (details.reason === 'clean-exit' || details.reason === 'killed') return false
+    if (details.type !== 'GPU' || details.reason !== 'crashed') return true
+
+    this.gpuCrashTimes = this.gpuCrashTimes.filter((time) => now - time <= this.gpuCrashWindowMs)
+    this.gpuCrashTimes.push(now)
+    if (this.gpuCrashTimes.length < this.gpuCrashThreshold) return false
+    this.gpuCrashTimes = []
+    return true
+  }
+}

--- a/apps/desktop-legalwork/src/main/runtime/runtime-probe-path.test.ts
+++ b/apps/desktop-legalwork/src/main/runtime/runtime-probe-path.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isRuntimeProbePath } from './runtime-probe-path'
+
+describe('isRuntimeProbePath', () => {
+  it('recognizes transient read endpoints including the knowledge tree', () => {
+    expect(isRuntimeProbePath('/v1/knowledge/tree?prefix=matter')).toBe(true)
+    expect(isRuntimeProbePath('/v1/threads')).toBe(true)
+    expect(isRuntimeProbePath('/data-compliance/tasks')).toBe(true)
+  })
+
+  it('does not suppress unrelated business endpoints', () => {
+    expect(isRuntimeProbePath('/v1/knowledge/files')).toBe(false)
+    expect(isRuntimeProbePath('/v1/turns')).toBe(false)
+  })
+})

--- a/apps/desktop-legalwork/src/main/runtime/runtime-probe-path.ts
+++ b/apps/desktop-legalwork/src/main/runtime/runtime-probe-path.ts
@@ -1,0 +1,20 @@
+/**
+ * Read-only navigation/probe endpoints can fail transiently while the managed
+ * runtime is starting or restarting. Callers still receive the failure, but
+ * these paths should not create automatic incident reports. Mutating requests
+ * are filtered separately by method at the call site.
+ */
+export function isRuntimeProbePath(pathAndQuery: string): boolean {
+  const pathname = pathAndQuery.split('?')[0] ?? ''
+  return (
+    pathname === '/health' ||
+    pathname === '/v1/runtime/info' ||
+    pathname === '/v1/runtime/tools' ||
+    pathname === '/v1/threads' ||
+    pathname.startsWith('/v1/threads/') ||
+    pathname === '/v1/memory' ||
+    pathname === '/v1/usage' ||
+    pathname === '/v1/knowledge/tree' ||
+    pathname.startsWith('/data-compliance/')
+  )
+}

--- a/apps/desktop-legalwork/src/main/runtime/unhealthy-owned-runtime.test.ts
+++ b/apps/desktop-legalwork/src/main/runtime/unhealthy-owned-runtime.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { recoverUnhealthyOwnedRuntime } from './unhealthy-owned-runtime'
+
+describe('recoverUnhealthyOwnedRuntime', () => {
+  it('stops a managed child that failed its health probe', async () => {
+    const stopAndWait = vi.fn(async () => {})
+
+    await expect(recoverUnhealthyOwnedRuntime({
+      isChildRunning: () => true,
+      stopAndWait
+    }, async () => false)).resolves.toBe('stopped')
+    expect(stopAndWait).toHaveBeenCalledOnce()
+  })
+
+  it('allows a managed child that completes startup during the late probe', async () => {
+    const stopAndWait = vi.fn(async () => {})
+
+    await expect(recoverUnhealthyOwnedRuntime({
+      isChildRunning: () => true,
+      stopAndWait
+    }, async () => true)).resolves.toBe('became-healthy')
+    expect(stopAndWait).not.toHaveBeenCalled()
+  })
+
+  it('leaves an externally owned port for the port-conflict path', async () => {
+    const stopAndWait = vi.fn(async () => {})
+
+    await expect(recoverUnhealthyOwnedRuntime({
+      isChildRunning: () => false,
+      stopAndWait
+    }, async () => false)).resolves.toBe('not-owned')
+    expect(stopAndWait).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop-legalwork/src/main/runtime/unhealthy-owned-runtime.ts
+++ b/apps/desktop-legalwork/src/main/runtime/unhealthy-owned-runtime.ts
@@ -1,0 +1,23 @@
+export type OwnedRuntimeController = {
+  isChildRunning(): boolean
+  stopAndWait(): Promise<void>
+}
+
+/**
+ * Stop a managed child that still owns the configured port but no longer
+ * answers health checks. Port reclamation cannot fix this case because the
+ * owner is this application itself.
+ */
+export type OwnedRuntimeRecoveryResult = 'not-owned' | 'became-healthy' | 'stopped'
+
+export async function recoverUnhealthyOwnedRuntime(
+  controller: OwnedRuntimeController,
+  probeCoreApi: () => Promise<boolean>
+): Promise<OwnedRuntimeRecoveryResult> {
+  if (!controller.isChildRunning()) return 'not-owned'
+  // A just-launched child can miss the fast probe. Give it one bounded chance
+  // to finish starting before classifying it as hung.
+  if (await probeCoreApi()) return 'became-healthy'
+  await controller.stopAndWait()
+  return 'stopped'
+}

--- a/skills/legal_document_formatting/scripts/skill_runner.py
+++ b/skills/legal_document_formatting/scripts/skill_runner.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Iterable
 
 RUNTIME_VERSION = "v5"
@@ -68,7 +68,19 @@ def marker_path(venv_root: Path) -> Path:
     return venv_root / f".legalwork-document-skill-{RUNTIME_VERSION}"
 
 
-def bundled_office_python_env(command: str) -> dict:
+def bundled_office_python_home(command: str, platform_name: str | None = None) -> str:
+    """Return the relocatable runtime root for a bundled interpreter.
+
+    The packaged layouts differ intentionally: Windows places python.exe at
+    ``python/python.exe`` while Unix places it at ``python/bin/python3``.
+    Walking two parents works only for the Unix layout.
+    """
+    if (platform_name or os.name) == "nt":
+        return str(PureWindowsPath(command).parent)
+    return str(Path(command).resolve().parent.parent)
+
+
+def bundled_office_python_env(command: str, platform_name: str | None = None) -> dict:
     """python-build-standalone hard-codes sys.prefix at build time and is not
     relocatable by default: once the tree is packaged under office-runtime/,
     the python still looks for its stdlib/site-packages under the build-time
@@ -76,9 +88,17 @@ def bundled_office_python_env(command: str) -> dict:
     fails on end-user machines and reports "incomplete or incompatible".
     """
     env = dict(os.environ)
-    home = str(Path(command).resolve().parent.parent)
-    env["PYTHONHOME"] = home
+    env["PYTHONHOME"] = bundled_office_python_home(command, platform_name)
     return env
+
+
+def is_bundled_office_python(command: str) -> bool:
+    explicit = os.environ.get("LEGALWORK_OFFICE_PYTHON", "").strip()
+    candidates = [office_runtime_python(resources_root() / "office-runtime")]
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    normalized = os.path.normcase(os.path.realpath(command))
+    return any(normalized == os.path.normcase(os.path.realpath(str(candidate))) for candidate in candidates)
 
 
 def python_version_ok(command: str, env: dict | None = None) -> bool:
@@ -283,6 +303,7 @@ def worker_path(kind: str) -> Path:
 def dispatch(kind: str, worker_args: list[str]) -> None:
     python = choose_bootstrap_python() if kind == "legacy" else ensure_runtime()
     worker = worker_path(kind)
+    env = bundled_office_python_env(python) if is_bundled_office_python(python) else None
     try:
         completed = subprocess.run(
             [python, str(worker), *worker_args],
@@ -291,6 +312,7 @@ def dispatch(kind: str, worker_args: list[str]) -> None:
             text=True,
             timeout=300,
             check=False,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         emit({

--- a/skills/legal_document_formatting/tests/test_skill_runner.py
+++ b/skills/legal_document_formatting/tests/test_skill_runner.py
@@ -6,6 +6,8 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 
 def _load_runner() -> object:
@@ -27,6 +29,38 @@ class BundledOfficePythonRelocationTest(unittest.TestCase):
         self.assertEqual(
             env["PYTHONHOME"],
             "/fake/app/resources/office-runtime/python",
+        )
+
+    def test_windows_env_reanchors_pythonhome_to_python_dir(self) -> None:
+        module = _load_runner()
+        windows = r"C:\Program Files\legalwork\resources\office-runtime\python\python.exe"
+        env = module.bundled_office_python_env(windows, platform_name="nt")
+        self.assertEqual(
+            env["PYTHONHOME"],
+            r"C:\Program Files\legalwork\resources\office-runtime\python",
+        )
+
+    def test_dispatch_preserves_pythonhome_for_bundled_worker(self) -> None:
+        module = _load_runner()
+        bundled = "/fake/resources/office-runtime/python/bin/python3"
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout='{"status":"ok"}\n',
+            stderr="",
+        )
+        with (
+            patch.object(module, "ensure_runtime", return_value=bundled),
+            patch.object(module, "worker_path", return_value=Path("/fake/worker.py")),
+            patch.object(module, "is_bundled_office_python", return_value=True),
+            patch.object(module.subprocess, "run", return_value=completed) as run,
+            patch("builtins.print"),
+        ):
+            with self.assertRaisesRegex(SystemExit, "0"):
+                module.dispatch("docx", [])
+
+        self.assertEqual(
+            run.call_args.kwargs["env"]["PYTHONHOME"],
+            "/fake/resources/office-runtime/python",
         )
 
     def test_real_bundled_python_imports_with_env(self) -> None:


### PR DESCRIPTION
## 修复内容

- 修复 LegalWork 自管 runtime 占用端口但核心 API 已失效时无法恢复的问题，增加一次有界复检并停止失效子进程后重启。
- 降低 renderer/GPU 正常退出、探测请求失败、read-before-edit 防护和过期 bash session 等预期场景的错误上报噪音。
- 修复打包后的 Windows Office Python `PYTHONHOME` 计算错误，并确保文档 worker 继承正确的 bundled runtime 环境。
- 知识库扫描跳过 `.venv`、`venv`、`__pycache__`、pytest/mypy/tox 缓存目录，避免把开发依赖目录误纳入知识库树。
- 强化 edit 工具的 read-before-edit 提示，并为过期 bash session 返回可恢复的结构化错误。

## 验证

- Runtime targeted tests: 187/187 passed
- Desktop main/runtime targeted tests: 8/8 passed
- Python document skill tests: 4/4 passed
- Runtime TypeScript typecheck: passed
- Desktop TypeScript typecheck: passed
- `git diff --check`: passed

分支基于当前 `main` (`9fd29537`)；仅领先一个提交 `3caec563`。