### PR TITLE
fix: resolve remaining v0.3.28 runtime reports

### DIFF
--- a/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-document-skill-tool.ts
+++ b/apps/desktop-legalwork/legalwork/src/adapters/tool/builtin-document-skill-tool.ts
@@ -256,7 +256,15 @@ export function createDocumentSkillExecuteTool(options: SkillToolsOptions = {}):
           isError: true
         }
       }
-      const skill = options.skillRuntime?.load(LEGAL_DOCUMENT_FORMATTING_SKILL_ID)
+      let skill = options.skillRuntime?.load(LEGAL_DOCUMENT_FORMATTING_SKILL_ID)
+      if (!skill && options.skillRuntime) {
+        // Runtime startup intentionally defers Skill discovery so the HTTP API
+        // becomes available quickly. A document request can arrive during that
+        // short window; refresh once on demand before declaring the bundled
+        // managed Skill unavailable.
+        await options.skillRuntime.refresh().catch(() => undefined)
+        skill = options.skillRuntime.load(LEGAL_DOCUMENT_FORMATTING_SKILL_ID)
+      }
       if (!skill) {
         return { output: { status: 'error', error: 'legal-document-formatting Skill is unavailable' }, isError: true }
       }

--- a/apps/desktop-legalwork/legalwork/src/server/node-http-server.test.ts
+++ b/apps/desktop-legalwork/legalwork/src/server/node-http-server.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { Router } from './router.js'
+import { startNodeHttpServer } from './node-http-server.js'
+
+describe('Node HTTP streaming adapter', () => {
+  it('flushes response headers before the first streaming body chunk is available', async () => {
+    const router = new Router()
+    let releaseBody: (() => void) | undefined
+    router.add('GET', '/events', () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseBody = () => {
+          controller.enqueue(new TextEncoder().encode('event: heartbeat\ndata: {}\n\n'))
+          controller.close()
+        }
+      }
+    }), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream; charset=utf-8' }
+    }))
+    const server = await startNodeHttpServer({ router, host: '127.0.0.1', port: 0 })
+    const responsePromise = fetch(`http://${server.host}:${server.port}/events`)
+
+    try {
+      const headersArrived = await Promise.race([
+        responsePromise.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 250))
+      ])
+      expect(headersArrived).toBe(true)
+    } finally {
+      releaseBody?.()
+      await responsePromise.catch(() => undefined)
+      await server.close()
+    }
+  })
+})

--- a/apps/desktop-legalwork/legalwork/src/server/node-http-server.ts
+++ b/apps/desktop-legalwork/legalwork/src/server/node-http-server.ts
@@ -91,6 +91,10 @@ async function writeFetchResponse(outgoing: ServerResponse, response: Response):
     outgoing.end()
     return
   }
+  // Streaming responses such as SSE may legitimately have no body bytes for
+  // several seconds. Flush the status line + headers immediately so fetch()
+  // resolves on the client before the first heartbeat/event arrives.
+  outgoing.flushHeaders()
   const reader = response.body.getReader()
   try {
     while (true) {

--- a/apps/desktop-legalwork/legalwork/tests/builtin-document-skill-tool.test.ts
+++ b/apps/desktop-legalwork/legalwork/tests/builtin-document-skill-tool.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createDocumentSkillExecuteTool,
   deterministicPdfPayloadError,
@@ -34,6 +34,37 @@ describe('document_skill_execute', () => {
     expect(properties.outputPath?.description).toContain('thread workspace')
     expect(tool.description).toContain('Do not probe with help/list')
     expect(tool.description).toContain('never pass cache-hygiene text')
+  })
+
+  it('refreshes deferred Skill discovery once before declaring the managed document Skill unavailable', async () => {
+    const skillRoot = join(root, 'managed-document-skill')
+    let refreshed = false
+    const refresh = vi.fn(async () => {
+      refreshed = true
+    })
+    const load = vi.fn(() => refreshed
+      ? {
+          id: 'legal-document-formatting',
+          name: 'legal-document-formatting',
+          root: skillRoot,
+          entryPath: join(skillRoot, 'SKILL.md'),
+          legacy: false,
+          source: 'native',
+          triggers: { commands: [], promptPatterns: [], fileTypes: [] },
+          allowedTools: [],
+          instructions: ''
+        }
+      : undefined)
+    const tool = createDocumentSkillExecuteTool({
+      skillRuntime: { load, refresh } as never
+    })
+
+    const result = await tool.execute({ kind: 'profile', operation: 'profiles' }, context())
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(result.isError).toBe(true)
+    expect(JSON.stringify(result.output)).not.toContain('legal-document-formatting Skill is unavailable')
   })
 
   it('prepares a Word worker invocation from inline Markdown without a bash intermediate file', async () => {

--- a/apps/desktop-legalwork/src/main/learning-iteration-runtime.test.ts
+++ b/apps/desktop-legalwork/src/main/learning-iteration-runtime.test.ts
@@ -195,6 +195,44 @@ describe('LearningIterationRuntime scheduling', () => {
     )
     runtime.stop()
   })
+
+  it('keeps a transient runtime disconnect queued instead of recording a failed learning iteration', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'legalwork-learning-transient-runtime-'))
+    tempRoots.push(dataDir)
+    const appSettings = settings(dataDir)
+    const runtimeRequest = vi.fn(async (_settings: AppSettingsV1, path: string) => {
+      if (path.startsWith('/v1/threads')) {
+        return {
+          ok: false,
+          status: 0,
+          body: JSON.stringify({ code: 'fetch_failed', message: 'fetch failed' })
+        }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const logError = vi.fn()
+    const runtime = createLearningIterationRuntime({
+      store: { load: vi.fn(async () => appSettings) } as never,
+      runtimeRequest,
+      getSystemIdleSeconds: () => 60 * 60,
+      getExternalBusy: async () => false,
+      logError
+    })
+
+    await runtime.queue()
+    await vi.waitFor(async () => {
+      const status = await runtime.status()
+      expect(status.status).toBe('waiting')
+      expect(status.message).toContain('运行时连接暂时中断')
+    })
+    const records = await runtime.list()
+    if (records.ok) expect(records.records).toEqual([])
+    expect(logError).not.toHaveBeenCalledWith(
+      'learning-iteration',
+      expect.stringContaining('fetch failed')
+    )
+    runtime.stop()
+  })
 })
 
 describe('learning model result parsing', () => {
@@ -202,6 +240,9 @@ describe('learning model result parsing', () => {
     expect(shouldReportLearningIterationError(new Error('Insufficient Balance (HTTP 402)'))).toBe(false)
     expect(shouldReportLearningIterationError(new Error('Memory confidence must be at least 0.8 for automatic capture.'))).toBe(false)
     expect(shouldReportLearningIterationError(new Error('学习结果不是有效 JSON。'))).toBe(false)
+    expect(shouldReportLearningIterationError(new Error('Unexpected non-whitespace character after JSON at position 493'))).toBe(false)
+    expect(shouldReportLearningIterationError(new Error('fetch failed'))).toBe(false)
+    expect(shouldReportLearningIterationError(new Error('Runtime restarted before this turn completed.'))).toBe(false)
     expect(shouldReportLearningIterationError(new Error('Legalwork did not report ready within 12000ms'))).toBe(true)
   })
 
@@ -239,6 +280,28 @@ describe('learning model result parsing', () => {
     const parsed = JSON.parse(repaired) as { summary: string }
 
     expect(parsed.summary).toBe('路径 C:\\legal\\quote\n第二行')
+  })
+
+  it('accepts the first complete learning JSON object when the model appends duplicate output', () => {
+    const first = JSON.stringify({
+      title: '第一次有效结果',
+      summary: '应保留第一个完整对象',
+      reportMarkdown: '',
+      memories: [],
+      skills: [],
+      rejected: []
+    })
+    const response = [
+      'BEGIN_LEARNING_RESULT',
+      first,
+      '{"title":"重复输出","memories":[],"skills":[],"rejected":[]}',
+      'END_LEARNING_RESULT'
+    ].join('\n')
+
+    expect(parseLearningModelResult(response)).toMatchObject({
+      title: '第一次有效结果',
+      summary: '应保留第一个完整对象'
+    })
   })
 
   it('does not alter already valid learning JSON', () => {

--- a/apps/desktop-legalwork/src/main/learning-iteration-runtime.ts
+++ b/apps/desktop-legalwork/src/main/learning-iteration-runtime.ts
@@ -34,6 +34,7 @@ import {
   runtimeErrorMessage,
   sleep,
   type RuntimeRequestFn,
+  type RuntimeRequestResult,
   type ThreadDetailJson
 } from './schedule-runtime-helpers'
 import {
@@ -76,13 +77,19 @@ const EMPTY_COUNTS: LearningIterationCounts = {
   rejected: 0
 }
 
+export function isRecoverableLearningRuntimeError(error: unknown): boolean {
+  const message = errorMessage(error)
+  return /(?:fetch failed|Runtime restarted before this turn completed|ECONNRESET|ECONNREFUSED|socket hang up|network (?:error|failure|failed)|connection (?:reset|refused))/i.test(message)
+}
+
 export function shouldReportLearningIterationError(error: unknown): boolean {
   const message = errorMessage(error)
   return !(
     /(?:insufficient balance|余额不足|配额.*耗尽|HTTP\s*402)/i.test(message) ||
     /configure a model API key|sign in to ChatGPT/i.test(message) ||
     /memory confidence must be at least/i.test(message) ||
-    /学习结果不是有效 JSON|not valid JSON|Unexpected token/i.test(message)
+    /学习结果不是有效 JSON|not valid JSON|Unexpected token|Unexpected non-whitespace character after JSON/i.test(message) ||
+    isRecoverableLearningRuntimeError(error)
   )
 }
 
@@ -485,6 +492,16 @@ export class LearningIterationRuntime {
     try {
       await this.run(settings, state)
     } catch (error) {
+      if (isRecoverableLearningRuntimeError(error)) {
+        await this.writeState(settings, {
+          ...state,
+          lastCheckedAt: this.now().toISOString(),
+          pendingRunId: this.activeRunId || state.pendingRunId
+        })
+        this.queued = true
+        this.message = '运行时连接暂时中断，已保留本轮并等待恢复'
+        return
+      }
       if (error instanceof LearningPausedError) {
         await this.writeState(settings, {
           ...state,
@@ -906,6 +923,7 @@ export class LearningIterationRuntime {
 
     const deadline = Date.now() + TURN_TIMEOUT_MS
     let lastText = ''
+    let consecutiveTransientPollFailures = 0
     while (Date.now() < deadline) {
       if (this.cancelRequested) {
         await this.interruptLearningTurn(settings, threadId, turnId)
@@ -915,11 +933,24 @@ export class LearningIterationRuntime {
       // Always poll the thread status — isBusy() should not prevent us from
       // seeing that the AI has finished, otherwise the loop can time out even
       // though the turn completed successfully.
-      const detailResponse = await this.request(
-        settings,
-        `/v1/threads/${encodeURIComponent(threadId)}`,
-        'GET'
-      )
+      let detailResponse: RuntimeRequestResult
+      try {
+        detailResponse = await this.request(
+          settings,
+          `/v1/threads/${encodeURIComponent(threadId)}`,
+          'GET'
+        )
+        consecutiveTransientPollFailures = 0
+      } catch (error) {
+        if (isRecoverableLearningRuntimeError(error)) {
+          consecutiveTransientPollFailures += 1
+          if (consecutiveTransientPollFailures <= 5) {
+            this.message = '运行时连接恢复中，正在继续等待本轮学习'
+            continue
+          }
+        }
+        throw error
+      }
       const detail = JSON.parse(detailResponse.body) as ThreadDetailJson
       lastText = latestAssistantText(detail, { turnId }) || lastText
       const turn = detail.turns?.find((item) => item.id === turnId)
@@ -1403,17 +1434,69 @@ export function parseLearningModelResult(text: string): LearningModelResult {
 }
 
 function parseLearningModelJson(jsonText: string): Partial<LearningModelResult> {
+  let originalError: unknown
   try {
     return JSON.parse(jsonText) as Partial<LearningModelResult>
-  } catch (originalError) {
-    const repaired = repairLearningModelJson(jsonText)
-    if (repaired === jsonText) throw originalError
+  } catch (error) {
+    originalError = error
+  }
+
+  const repaired = repairLearningModelJson(jsonText)
+  const candidates = repaired === jsonText ? [jsonText] : [repaired, jsonText]
+  for (const candidate of candidates) {
+    if (candidate !== jsonText) {
+      try {
+        return JSON.parse(candidate) as Partial<LearningModelResult>
+      } catch {
+        // Fall through to prefix recovery below.
+      }
+    }
+    const firstObject = extractFirstCompleteJsonObject(candidate)
+    if (!firstObject || firstObject.trim() === candidate.trim()) continue
     try {
-      return JSON.parse(repaired) as Partial<LearningModelResult>
+      return JSON.parse(firstObject) as Partial<LearningModelResult>
     } catch {
-      throw originalError
+      // Keep the original parser error so the repair turn sees the real fault.
     }
   }
+  throw originalError
+}
+
+function extractFirstCompleteJsonObject(text: string): string | undefined {
+  const start = text.indexOf('{')
+  if (start < 0) return undefined
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === '"') inString = false
+      continue
+    }
+    if (char === '"') {
+      inString = true
+      continue
+    }
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) return text.slice(start, index + 1)
+      if (depth < 0) return undefined
+    }
+  }
+  return undefined
 }
 
 /**

--- a/apps/desktop-legalwork/src/main/process-gone-policy.test.ts
+++ b/apps/desktop-legalwork/src/main/process-gone-policy.test.ts
@@ -20,8 +20,17 @@ describe('process-gone reporting policy', () => {
     expect(policy.shouldReport(details, false, 3_000)).toBe(true)
   })
 
-  it('still reports non-GPU child crashes immediately', () => {
+  it('debounces isolated Utility crashes because Chromium restarts those helper processes too', () => {
+    const policy = new ChildProcessGoneReportPolicy(3, 60_000)
+    const details = { type: 'Utility', reason: 'crashed', exitCode: -1073741205 }
+
+    expect(policy.shouldReport(details, false, 1_000)).toBe(false)
+    expect(policy.shouldReport(details, false, 2_000)).toBe(false)
+    expect(policy.shouldReport(details, false, 3_000)).toBe(true)
+  })
+
+  it('still reports other child crashes immediately', () => {
     const policy = new ChildProcessGoneReportPolicy()
-    expect(policy.shouldReport({ type: 'Utility', reason: 'crashed', exitCode: 1 }, false)).toBe(true)
+    expect(policy.shouldReport({ type: 'Audio Service', reason: 'crashed', exitCode: 1 }, false)).toBe(true)
   })
 })

--- a/apps/desktop-legalwork/src/main/process-gone-policy.ts
+++ b/apps/desktop-legalwork/src/main/process-gone-policy.ts
@@ -12,10 +12,11 @@ export function shouldReportRenderProcessGone(
   return details.reason !== 'clean-exit' && details.reason !== 'killed'
 }
 
-/** Electron normally restarts an isolated GPU process crash. Report only a
- * repeated crash burst, which is actionable evidence of a persistent fault. */
+/** Electron normally restarts isolated GPU and Utility helper processes.
+ * Report only a repeated crash burst for those helpers; a single crash is
+ * usually Chromium self-recovery rather than an actionable app failure. */
 export class ChildProcessGoneReportPolicy {
-  private gpuCrashTimes: number[] = []
+  private recoverableCrashTimes = new Map<string, number[]>()
 
   constructor(
     private readonly gpuCrashThreshold = 3,
@@ -25,12 +26,17 @@ export class ChildProcessGoneReportPolicy {
   shouldReport(details: ProcessGoneDetails, isQuitting: boolean, now = Date.now()): boolean {
     if (isQuitting) return false
     if (details.reason === 'clean-exit' || details.reason === 'killed') return false
-    if (details.type !== 'GPU' || details.reason !== 'crashed') return true
+    if (!['GPU', 'Utility'].includes(details.type ?? '') || details.reason !== 'crashed') return true
 
-    this.gpuCrashTimes = this.gpuCrashTimes.filter((time) => now - time <= this.gpuCrashWindowMs)
-    this.gpuCrashTimes.push(now)
-    if (this.gpuCrashTimes.length < this.gpuCrashThreshold) return false
-    this.gpuCrashTimes = []
+    const type = details.type ?? 'unknown'
+    const recent = (this.recoverableCrashTimes.get(type) ?? [])
+      .filter((time) => now - time <= this.gpuCrashWindowMs)
+    recent.push(now)
+    if (recent.length < this.gpuCrashThreshold) {
+      this.recoverableCrashTimes.set(type, recent)
+      return false
+    }
+    this.recoverableCrashTimes.delete(type)
     return true
   }
 }

--- a/apps/desktop-legalwork/src/renderer/src/store/chat-store-navigation-actions.test.ts
+++ b/apps/desktop-legalwork/src/renderer/src/store/chat-store-navigation-actions.test.ts
@@ -13,10 +13,10 @@ describe('withinRuntimeProbeBudget', () => {
     await expect(withinRuntimeProbeBudget(Promise.resolve('ready'))).resolves.toBe('ready')
   })
 
-  it('stops waiting after five seconds instead of staying in connecting', async () => {
+  it('stops waiting at the configured probe budget instead of staying in connecting', async () => {
     vi.useFakeTimers()
     const result = withinRuntimeProbeBudget(new Promise<never>(() => undefined))
-    const assertion = expect(result).rejects.toThrow(/5/)
+    const assertion = expect(result).rejects.toThrow()
 
     await vi.advanceTimersByTimeAsync(RUNTIME_PROBE_BUDGET_MS)
 


### PR DESCRIPTION
## What this fixes

- recover learning-iteration JSON when a model appends duplicate/trailing output (#1551)
- treat transient runtime disconnect/restart during learning as recoverable instead of a failed iteration (#1541, #1533)
- refresh deferred Skill discovery on first document tool use before reporting the bundled Skill unavailable (#1545)
- flush Node streaming response headers immediately so SSE no longer races the 15s heartbeat against the 15s start timeout (#1544, #1542, #1519, #1498)
- debounce isolated Chromium Utility crashes the same way as GPU helper crashes (#1549, #1547)
- repair a stale v0.3.25 probe-budget test that still expected 5s after the product budget moved to 10s

## Verification

- runtime targeted tests: 17/17 passed
- desktop targeted tests: 21/21 passed
- runtime full suite: 853/853 passed
- desktop full suite: 1206/1206 passed
- runtime typecheck: passed
- desktop typecheck: passed
- desktop production build: passed
- git diff --check: passed
